### PR TITLE
Merge SuperAdmin role into Admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ Open the app:
 
 Demo accounts (created automatically):
 
-- `superadmin@pure3d.eu` / `1234567890`
 - `admin@pure3d.eu` / `1234567890`
 - `editor@pure3d.eu` / `1234567890`
 - `viewer@pure3d.eu` / `1234567890`

--- a/docs/ROLES.md
+++ b/docs/ROLES.md
@@ -1,17 +1,16 @@
 # Pure3D Role-Based Access Control (RBAC)
 
-This document defines the role system for the Pure3D platform, covering all 7 roles, their permissions, and the editorial workflow.
+This document defines the role system for the Pure3D platform, covering all roles, their permissions, and the editorial workflow.
 
 ## Role Definitions
 
 ### Global Roles
 
-These roles are assigned system-wide in the `users` collection.
+These roles are assigned system-wide in the `userProfiles` collection.
 
 | Role | Who | Scope |
 |------|-----|-------|
-| **Super Admin** | Platform maintainers, KNAW/HuC staff | Full system access. Can manage all users, collections, editions, and platform settings. |
-| **Admin** | Trusted staff or delegated managers | Can manage users and oversee all collections/editions. Cannot modify platform-level settings. |
+| **Admin** | Platform maintainers, KNAW/HuC staff | Full system access. Can manage all users, collections, editions, and platform settings. |
 | **Editorial Board** | Appointed reviewers for peer review | Can review submitted editions across all collections. Cannot create or edit content. |
 | **Viewer** | Default role for registered users | Can browse published content. No editing or management permissions. |
 
@@ -37,114 +36,97 @@ These roles are assigned per-edition in the `editionUsers` join table.
 
 ## Permission Matrix
 
-Actions marked with the role that can perform them. Global roles (SA=Super Admin, A=Admin, EB=Editorial Board, V=Viewer) and scoped roles (CO=Collection Owner, E=Editor, Au=Author, Cl=Collaborator, R=Reviewer).
+Actions marked with the role that can perform them. Global roles (A=Admin, EB=Editorial Board, V=Viewer) and scoped roles (CO=Collection Owner, E=Editor, Au=Author, Cl=Collaborator, R=Reviewer).
 
 ### Edition Lifecycle
 
-| Action | SA | A | EB | V | CO | E | Au | Cl | R |
-|--------|:--:|:-:|:--:|:-:|:--:|:-:|:--:|:--:|:-:|
-| Create edition | x | x | | | x | | | | |
-| Edit edition content | x | x | | | x | x | x | x | |
-| Delete edition | x | x | | | x | | | | |
-| View draft edition | x | x | | | x | x | x | x | x |
-| Submit for review | x | x | | | x | | x | | |
-| Approve/reject edition | x | | x | | | | | | x |
-| Publish edition | x | x | | | x | | | | |
-| Unpublish edition | x | x | | | x | | | | |
+| Action | A | EB | V | CO | E | Au | Cl | R |
+|--------|:-:|:--:|:-:|:--:|:-:|:--:|:--:|:-:|
+| Create edition | x | | | x | | | | |
+| Edit edition content | x | | | x | x | x | x | |
+| Delete edition | x | | | x | | | | |
+| View draft edition | x | | | x | x | x | x | x |
+| Submit for review | x | | | x | | x | | |
+| Approve/reject edition | x | x | | | | | | x |
+| Publish edition | x | | | x | | | | |
+| Unpublish edition | x | | | x | | | | |
 
 ### Collection Management
 
-| Action | SA | A | EB | V | CO | E |
-|--------|:--:|:-:|:--:|:-:|:--:|:-:|
-| Create collection | x | x | | | | |
-| Edit collection metadata | x | x | | | x | x |
-| Delete collection | x | x | | | x | |
-| Manage collection users | x | x | | | x | |
+| Action | A | EB | V | CO | E |
+|--------|:-:|:--:|:-:|:--:|:-:|
+| Create collection | x | | | | |
+| Edit collection metadata | x | | | x | x |
+| Delete collection | x | | | x | |
+| Manage collection users | x | | | x | |
 
 ### User & Platform Management
 
-| Action | SA | A | EB | V |
-|--------|:--:|:-:|:--:|:-:|
-| View admin panel | x | x | | |
-| Manage user global roles | x | x | | |
-| Manage platform settings | x | | | |
-| View all users | x | x | | |
+| Action | A | EB | V |
+|--------|:-:|:--:|:-:|
+| View admin panel | x | | |
+| Manage user global roles | x | | |
+| View all users | x | | |
 
 ### Content Browsing
 
-| Action | SA | A | EB | V |
-|--------|:--:|:-:|:--:|:-:|
-| Browse published editions | x | x | x | x |
-| Browse published collections | x | x | x | x |
-| Search/filter content | x | x | x | x |
-| View own profile | x | x | x | x |
+| Action | A | EB | V |
+|--------|:-:|:--:|:-:|
+| Browse published editions | x | x | x |
+| Browse published collections | x | x | x |
+| Search/filter content | x | x | x |
+| View own profile | x | x | x |
 
 ## Editorial Workflow
 
-Editions follow a review workflow with defined status transitions:
-
-```
-                    ┌──────────┐
-                    │  Draft   │
-                    └────┬─────┘
-                         │ submit
-                         ▼
-                    ┌──────────┐
-                    │Submitted │
-                    └────┬─────┘
-                         │ begin review
-                         ▼
-                    ┌──────────┐
-              ┌─────│In Review │─────┐
-              │     └──────────┘     │
-              │ approve              │ reject
-              ▼                      ▼
-        ┌──────────┐          ┌──────────┐
-        │ Approved │          │ Rejected │
-        └────┬─────┘          └────┬─────┘
-             │ publish              │ revise (→ Draft)
-             ▼                      │
-        ┌──────────┐               │
-        │Published │               │
-        └──────────┘               │
-                                    ▼
-                              ┌──────────┐
-                              │  Draft   │
-                              └──────────┘
-```
+Editions follow a multi-stage review workflow with defined status transitions.
 
 ### Status Definitions
 
 | Status | Description |
 |--------|-------------|
 | `draft` | Edition is being worked on. Only visible to assigned users. |
-| `submitted` | Author has submitted the edition for peer review. |
-| `in_review` | Editorial board / reviewers are actively reviewing. |
-| `approved` | Review passed. Ready to be published by collection owner or admin. |
-| `rejected` | Review failed. Author must revise and resubmit. Returns to draft. |
+| `concept_submitted` | Author has submitted the concept for review. |
+| `editorial_review` | Editorial board is reviewing the concept. |
+| `concept_accepted` | Concept approved. Ready for alpha stage. |
+| `concept_rejected` | Concept rejected. Author must revise and resubmit. |
+| `alpha_review` | Reviewers are evaluating the alpha version. |
+| `alpha_revisions` | Revisions requested during alpha review. |
+| `alpha_accepted` | Alpha accepted. Ready for final review. |
+| `alpha_rejected` | Alpha rejected. Returns to draft. |
+| `final_review` | Final review before publication. |
+| `final_revisions` | Revisions requested during final review. |
 | `published` | Edition is publicly visible to all users. |
 
 ### Valid Status Transitions
 
 | From | To | Who Can Trigger |
 |------|----|-----------------|
-| `draft` | `submitted` | Author, Collection Owner, Super Admin, Admin |
-| `submitted` | `in_review` | Editorial Board, Reviewer, Super Admin, Admin |
-| `in_review` | `approved` | Editorial Board, Reviewer, Super Admin |
-| `in_review` | `rejected` | Editorial Board, Reviewer, Super Admin |
-| `approved` | `published` | Collection Owner, Super Admin, Admin |
-| `rejected` | `draft` | Author, Collection Owner, Super Admin, Admin |
-| `published` | `draft` | Collection Owner, Super Admin, Admin |
+| `draft` | `concept_submitted` | Author, Collection Owner, Admin |
+| `concept_submitted` | `editorial_review` | Editorial Board, Reviewer, Admin |
+| `editorial_review` | `concept_accepted` | Editorial Board, Reviewer, Admin |
+| `editorial_review` | `concept_rejected` | Editorial Board, Reviewer, Admin |
+| `concept_accepted` | `alpha_review` | Admin |
+| `concept_rejected` | `draft` | Author, Collection Owner, Admin |
+| `alpha_review` | `alpha_accepted` | Editorial Board, Reviewer, Admin |
+| `alpha_review` | `alpha_rejected` | Editorial Board, Reviewer, Admin |
+| `alpha_review` | `alpha_revisions` | Editorial Board, Reviewer, Admin |
+| `alpha_revisions` | `alpha_review` | Author, Collection Owner, Admin |
+| `alpha_accepted` | `final_review` | Admin |
+| `alpha_rejected` | `draft` | Author, Collection Owner, Admin |
+| `final_review` | `published` | Collection Owner, Admin |
+| `final_review` | `final_revisions` | Editorial Board, Reviewer, Admin |
+| `final_revisions` | `final_review` | Author, Collection Owner, Admin |
+| `published` | `draft` | Collection Owner, Admin |
 
 ## PocketBase Schema Mapping
 
-### Global Roles → `users.role` (select field)
+### Global Roles → `userProfiles.role` (select field)
 
 ```
-superadmin  → Super Admin
-admin       → Admin
+admin           → Admin
 editorial_board → Editorial Board
-viewer      → Viewer (default for new registrations)
+viewer          → Viewer (default for new registrations)
 ```
 
 ### Collection Roles → `collectionUsers.role` (select field)
@@ -166,45 +148,11 @@ reviewer     → Reviewer
 ### Edition Status → `editions.status` (select field)
 
 ```
-draft | submitted | in_review | approved | rejected | published
+draft | concept_submitted | editorial_review | concept_accepted | concept_rejected |
+alpha_review | alpha_revisions | alpha_accepted | alpha_rejected |
+final_review | final_revisions | published
 ```
 
-### Auth Linking → `users.pbAuthId` (text field, unique)
+### Auth Linking → `userProfiles.pbAuthId` (text field, unique)
 
-The `users` collection (app data) stores a `pbAuthId` field that links to the PocketBase built-in auth user ID. This bridges the gap between PocketBase authentication and the application's user data model.
-
-## Gap Analysis: Current vs Target State
-
-### Current State
-
-| Area | Status |
-|------|--------|
-| `users.role` values | `root`, `admin`, `editor`, `viewer` — generic, doesn't match partner requirements |
-| `collectionUsers.role` values | `admin`, `editor`, `viewer` — no "owner" concept |
-| `editionUsers.role` values | `admin`, `editor`, `viewer` — no author/collaborator/reviewer distinction |
-| Edition status/workflow | No `status` field. Only `isPublished` boolean. No review workflow. |
-| Permission checking | None. No middleware or utility functions check roles before actions. |
-| Auth ↔ App user link | PB auth users and app `users` collection are separate, linked only by email (fragile). |
-| Admin UI | No admin page exists. Role management requires direct PocketBase admin access. |
-| Profile page | Hardcodes role as `'user'` regardless of actual role. |
-
-### Target State (This Implementation)
-
-| Area | Status |
-|------|--------|
-| `users.role` values | `superadmin`, `admin`, `editorial_board`, `viewer` — matches partner diagram |
-| `collectionUsers.role` values | `owner`, `editor`, `viewer` — explicit ownership |
-| `editionUsers.role` values | `author`, `collaborator`, `reviewer` — clear responsibilities |
-| Edition status/workflow | `status` select field with 6 states and defined transitions |
-| Permission checking | `permissions.ts` utility with `hasPermission()`, `canTransitionStatus()`, etc. |
-| Auth ↔ App user link | `pbAuthId` field links PB auth to app user; auth store resolves role on login |
-| Admin UI | `/admin/users` page for viewing and managing user roles |
-| Profile page | Shows actual global role from auth store |
-
-### Future Work (Not in This Implementation)
-
-- Server-side middleware enforcing permissions on all data access
-- Collection-level and edition-level role assignment UIs
-- PocketBase API rules using role-based filters
-- Audit logging for role changes and status transitions
-- Email notifications for workflow events (submission, review, approval)
+The `userProfiles` collection (app data) stores a `pbAuthId` field that links to the PocketBase built-in auth user ID. This bridges the gap between PocketBase authentication and the application's user data model.

--- a/docs/setup/quick-start.md
+++ b/docs/setup/quick-start.md
@@ -26,7 +26,6 @@ On a new machine, `docker compose up -d` will:
 
 These are created automatically for local development:
 
-- `superadmin@pure3d.eu` / `1234567890`
 - `admin@pure3d.eu` / `1234567890`
 - `editor@pure3d.eu` / `1234567890`
 - `viewer@pure3d.eu` / `1234567890`

--- a/pocketbase/pb_schema/collections.json
+++ b/pocketbase/pb_schema/collections.json
@@ -24,7 +24,6 @@
 				"required": true,
 				"maxSelect": 1,
 				"values": [
-					"superadmin",
 					"admin",
 					"editorial_board",
 					"viewer"

--- a/pocketbase/pb_schema/seed_users.json
+++ b/pocketbase/pb_schema/seed_users.json
@@ -1,11 +1,5 @@
 [
   {
-    "email": "superadmin@pure3d.eu",
-    "password": "1234567890",
-    "nickname": "SuperAdmin",
-    "role": "superadmin"
-  },
-  {
     "email": "admin@pure3d.eu",
     "password": "1234567890",
     "nickname": "Admin",

--- a/scripts/create-pocketbase-collections.ts
+++ b/scripts/create-pocketbase-collections.ts
@@ -19,7 +19,7 @@ const openRules = {
 	deleteRule: ''
 };
 
-const globalRoleValues = ['superadmin', 'admin', 'editorial_board', 'viewer'];
+const globalRoleValues = ['admin', 'editorial_board', 'viewer'];
 const collectionRoleValues = ['owner', 'editor', 'viewer'];
 const editionRoleValues = ['author', 'collaborator', 'reviewer'];
 const editionStatusValues = [
@@ -415,7 +415,10 @@ async function main() {
 		name: 'editionReviews',
 		type: 'base',
 		fields: [
-			relationField('editionId', collectionIds['editions'], { required: true, cascadeDelete: true }),
+			relationField('editionId', collectionIds['editions'], {
+				required: true,
+				cascadeDelete: true
+			}),
 			relationField('reviewerId', collectionIds['userProfiles'], { required: true }),
 			{ name: 'reviewStage', type: 'number', required: true },
 			{
@@ -433,7 +436,10 @@ async function main() {
 		name: 'reviewAssignments',
 		type: 'base',
 		fields: [
-			relationField('editionId', collectionIds['editions'], { required: true, cascadeDelete: true }),
+			relationField('editionId', collectionIds['editions'], {
+				required: true,
+				cascadeDelete: true
+			}),
 			relationField('reviewerId', collectionIds['userProfiles'], { required: true }),
 			relationField('assignedBy', collectionIds['userProfiles'], { required: true }),
 			{ name: 'reviewStage', type: 'number', required: true },
@@ -451,7 +457,10 @@ async function main() {
 		name: 'reviewFeedback',
 		type: 'base',
 		fields: [
-			relationField('editionId', collectionIds['editions'], { required: true, cascadeDelete: true }),
+			relationField('editionId', collectionIds['editions'], {
+				required: true,
+				cascadeDelete: true
+			}),
 			relationField('reviewerId', collectionIds['userProfiles'], { required: true }),
 			{ name: 'reviewStage', type: 'number', required: true },
 			{
@@ -471,7 +480,10 @@ async function main() {
 		name: 'notifications',
 		type: 'base',
 		fields: [
-			relationField('recipientId', collectionIds['userProfiles'], { required: true, cascadeDelete: true }),
+			relationField('recipientId', collectionIds['userProfiles'], {
+				required: true,
+				cascadeDelete: true
+			}),
 			relationField('editionId', collectionIds['editions'], { cascadeDelete: true }),
 			{
 				name: 'type',

--- a/scripts/import-data.ts
+++ b/scripts/import-data.ts
@@ -18,7 +18,6 @@ const pb = new PocketBase(PB_URL);
 function mapGlobalRole(role?: string) {
 	switch (role) {
 		case 'root':
-			return 'superadmin';
 		case 'admin':
 			return 'admin';
 		case 'editorial_board':
@@ -203,7 +202,9 @@ async function main() {
 	console.log('\nImporting user profiles...');
 	const usersData = readJsonArray<any>('user.json');
 	const existingProfiles = await pb.collection('userProfiles').getFullList();
-	const existingProfileEmails = new Set(existingProfiles.map((record: any) => normalizeEmail(record.email)));
+	const existingProfileEmails = new Set(
+		existingProfiles.map((record: any) => normalizeEmail(record.email))
+	);
 
 	for (const record of existingProfiles) {
 		if (record.userHash) {

--- a/src/lib/components/ui/Header.svelte
+++ b/src/lib/components/ui/Header.svelte
@@ -97,7 +97,7 @@
 						My Work
 					</a>
 				{/if}
-				{#if authStore.isAuthenticated && (authStore.globalRole === GlobalRole.SuperAdmin || authStore.globalRole === GlobalRole.Admin)}
+				{#if authStore.isAuthenticated && authStore.globalRole === GlobalRole.Admin}
 					<a
 						class="btn btn-ghost"
 						class:btn-active={isActive('/admin')}

--- a/src/lib/components/ui/Login/EmailLoginForm.svelte
+++ b/src/lib/components/ui/Login/EmailLoginForm.svelte
@@ -10,7 +10,6 @@
 	let isLoading = $state(false);
 
 	const demoAccounts = [
-		{ label: 'Super Admin', email: 'superadmin@pure3d.eu', role: 'superadmin' },
 		{ label: 'Admin', email: 'admin@pure3d.eu', role: 'admin' },
 		{ label: 'Editorial Board', email: 'editor@pure3d.eu', role: 'editorial_board' },
 		{ label: 'Viewer', email: 'viewer@pure3d.eu', role: 'viewer' }
@@ -92,7 +91,7 @@
 
 		<button
 			type="submit"
-			class="btn btn-outline btn-secondary w-full"
+			class="btn w-full btn-outline btn-secondary"
 			disabled={isLoading}
 			aria-busy={isLoading}
 		>
@@ -107,7 +106,7 @@
 					{#each demoAccounts as account (account.email)}
 						<button
 							type="button"
-							class="badge badge-outline badge-sm cursor-pointer gap-1 transition-colors hover:badge-neutral"
+							class="badge cursor-pointer gap-1 badge-outline badge-sm transition-colors hover:badge-neutral"
 							onclick={() => fillDemo(account)}
 						>
 							{account.label}

--- a/src/lib/types/roles.ts
+++ b/src/lib/types/roles.ts
@@ -1,6 +1,5 @@
 // Global roles assigned system-wide in the `users` collection
 export enum GlobalRole {
-	SuperAdmin = 'superadmin',
 	Admin = 'admin',
 	EditorialBoard = 'editorial_board',
 	Viewer = 'viewer'
@@ -95,8 +94,7 @@ export enum Permission {
 
 	// User & platform management
 	AdminViewPanel = 'admin:view_panel',
-	AdminManageUsers = 'admin:manage_users',
-	AdminManagePlatform = 'admin:manage_platform'
+	AdminManageUsers = 'admin:manage_users'
 }
 
 // Valid edition status transitions: from → allowed targets
@@ -123,8 +121,7 @@ export const EDITION_STATUS_TRANSITIONS: Record<EditionStatus, EditionStatus[]> 
 export const GLOBAL_ROLE_HIERARCHY: GlobalRole[] = [
 	GlobalRole.Viewer,
 	GlobalRole.EditorialBoard,
-	GlobalRole.Admin,
-	GlobalRole.SuperAdmin
+	GlobalRole.Admin
 ];
 
 // Context object for permission checks
@@ -137,7 +134,6 @@ export interface UserRoleContext {
 // Display-friendly labels for all roles
 // Display-friendly labels for global roles
 export const GLOBAL_ROLE_LABELS: Record<GlobalRole, string> = {
-	[GlobalRole.SuperAdmin]: 'Super Admin',
 	[GlobalRole.Admin]: 'Admin',
 	[GlobalRole.EditorialBoard]: 'Editorial Board',
 	[GlobalRole.Viewer]: 'Viewer'

--- a/src/lib/utils/permissions.ts
+++ b/src/lib/utils/permissions.ts
@@ -32,9 +32,6 @@ export function canTransitionStatus(current: EditionStatus, target: EditionStatu
 export function hasPermission(context: UserRoleContext, permission: Permission): boolean {
 	const { globalRole, collectionRole, editionRole } = context;
 
-	// Super Admin has all permissions
-	if (globalRole === GlobalRole.SuperAdmin) return true;
-
 	switch (permission) {
 		// --- Edition actions ---
 		case Permission.EditionCreate:
@@ -135,9 +132,6 @@ export function hasPermission(context: UserRoleContext, permission: Permission):
 		case Permission.AdminManageUsers:
 			return globalRole === GlobalRole.Admin;
 
-		case Permission.AdminManagePlatform:
-			return false; // Only SuperAdmin (handled above)
-
 		default:
 			return false;
 	}
@@ -153,9 +147,6 @@ export function canUserTransitionStatus(
 	target: EditionStatus
 ): boolean {
 	if (!canTransitionStatus(current, target)) return false;
-
-	// SuperAdmin can do all valid transitions
-	if (context.globalRole === GlobalRole.SuperAdmin) return true;
 
 	switch (target) {
 		// --- Concept stage ---

--- a/src/lib/utils/review-helpers.ts
+++ b/src/lib/utils/review-helpers.ts
@@ -101,12 +101,12 @@ export function getTargetStatusFromVerdict(
 }
 
 /**
- * Get userProfile IDs of all admin and superadmin users.
+ * Get userProfile IDs of all admin users.
  */
 export async function getAdminUserIds(): Promise<string[]> {
 	try {
 		const result = await pb.collection('userProfiles').getList(1, 500, {
-			filter: `role = "${GlobalRole.Admin}" || role = "${GlobalRole.SuperAdmin}"`
+			filter: `role = "${GlobalRole.Admin}"`
 		});
 		return result.items.map((r) => r.id);
 	} catch {

--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -47,10 +47,7 @@
 			goto(resolveRoute('/', {}));
 			return;
 		}
-		if (
-			authStore.globalRole !== GlobalRole.SuperAdmin &&
-			authStore.globalRole !== GlobalRole.Admin
-		) {
+		if (authStore.globalRole !== GlobalRole.Admin) {
 			goto(resolveRoute('/', {}));
 			return;
 		}

--- a/src/routes/editions/[slug]/workflow/+page.svelte
+++ b/src/routes/editions/[slug]/workflow/+page.svelte
@@ -48,9 +48,7 @@
 	let isReviewer = $state(false);
 	let myAssignment = $state<ReviewAssignment | null>(null);
 	let myExistingReview = $state<EditionReview | null>(null);
-	let isAdmin = $derived(
-		authStore.globalRole === GlobalRole.SuperAdmin || authStore.globalRole === GlobalRole.Admin
-	);
+	let isAdmin = $derived(authStore.globalRole === GlobalRole.Admin);
 
 	// Concept form state
 	let conceptTitle = $state('');


### PR DESCRIPTION
## Summary

- Removes the `SuperAdmin` global role entirely, consolidating all its permissions into the existing `Admin` role
- There was no functional difference between SuperAdmin and Admin aside from a single `AdminManagePlatform` permission that always returned `false` for Admin (gated behind the SuperAdmin early-return). Since no UI or feature ever used that permission, the two roles were effectively identical.
- Updates all TypeScript enums, permission checks, PocketBase schema definitions, seed data, import scripts, documentation, and UI components to reflect the simplified three-role model: Admin, Editorial Board, Viewer

## Changes

- **`src/lib/types/roles.ts`**: Remove `SuperAdmin` enum value, `AdminManagePlatform` permission, hierarchy entry, and label
- **`src/lib/utils/permissions.ts`**: Remove SuperAdmin early returns and dead `AdminManagePlatform` case
- **`src/lib/utils/review-helpers.ts`**: Simplify admin user filter to only match `Admin`
- **UI components** (Header, EmailLoginForm, admin layout, workflow page): Simplify role checks from `SuperAdmin || Admin` to just `Admin`
- **PocketBase schema** (`collections.json`, `seed_users.json`): Remove `superadmin` value and seed user
- **Scripts** (`create-pocketbase-collections.ts`, `import-data.ts`): Remove `superadmin` from role values; map legacy `root` role to `admin`
- **Docs** (`ROLES.md`, `quick-start.md`, `README.md`): Remove all SuperAdmin references

## Test plan

- [ ] Verify the admin panel guard redirects non-admin users
- [x] Verify the demo accounts dropdown no longer shows "Super Admin"
- [ ] Verify workflow page correctly identifies admin users
- [ ] Run `bun run check` to confirm no type errors from the removed enum values