### PR TITLE
Add edition creation page and collection CRUD

### DIFF
--- a/src/lib/database/edition-helpers.ts
+++ b/src/lib/database/edition-helpers.ts
@@ -69,3 +69,30 @@ export async function updateReviewAssignmentStatus(id: string, status: ReviewAss
 export async function removeReviewAssignment(id: string) {
 	return pb.collection('reviewAssignments').delete(id);
 }
+
+export async function createEdition(data: {
+	title: string;
+	description: string;
+	peerReviewRequested: boolean;
+	collectionId?: string;
+	creatorUserId: string;
+}): Promise<string> {
+	const record = await pb.collection('editions').create({
+		dcTitle: data.title,
+		dcAbstract: data.description,
+		status: EditionStatus.Draft,
+		isPublished: false,
+		peerReviewRequested: data.peerReviewRequested,
+		collection: data.collectionId || null,
+		reviewStage: null
+	});
+
+	await pb.collection('editionUsers').create({
+		editionId: record.id,
+		userId: data.creatorUserId,
+		user: data.creatorUserId,
+		role: EditionRole.Author
+	});
+
+	return record.id;
+}

--- a/src/lib/utils/audit.ts
+++ b/src/lib/utils/audit.ts
@@ -14,7 +14,9 @@ export type AuditAction =
 	| 'feedback_created'
 	| 'feedback_resolved'
 	| 'collaborator_added'
-	| 'collaborator_removed';
+	| 'collaborator_removed'
+	| 'edition_created'
+	| 'collection_created';
 
 export type AuditTargetType = 'user' | 'collection' | 'edition';
 

--- a/src/routes/admin/collections/+page.svelte
+++ b/src/routes/admin/collections/+page.svelte
@@ -10,6 +10,7 @@
 	interface AdminCollection {
 		id: string;
 		title: string;
+		description: string;
 		isVisible: boolean;
 		pubNum: number;
 		thumbnailUrl: string;
@@ -33,6 +34,7 @@
 	let isLoading = $state(true);
 	let searchQuery = $state('');
 	let expandedId = $state<string | null>(null);
+	let activeTab = $state<'details' | 'members'>('details');
 	let filteredCollections = $derived(
 		searchQuery
 			? collections.filter((c) => c.title.toLowerCase().includes(searchQuery.toLowerCase()))
@@ -47,6 +49,22 @@
 	let addUserId = $state('');
 	let addRole = $state<CollectionRole>(CollectionRole.Viewer);
 	let isAdding = $state(false);
+
+	// Create collection form
+	let showCreateModal = $state(false);
+	let createTitle = $state('');
+	let createDescription = $state('');
+	let isCreatingCollection = $state(false);
+
+	// Edit collection form
+	let editTitle = $state('');
+	let editDescription = $state('');
+	let editIsVisible = $state(false);
+	let editThumbnailFile = $state<File | null>(null);
+	let editThumbnailPreview = $state('');
+	let isSavingDetails = $state(false);
+	let isDeleting = $state(false);
+	let showDeleteConfirm = $state(false);
 
 	const collectionRoleValues = Object.values(CollectionRole);
 
@@ -63,7 +81,8 @@
 			});
 			collections = result.items.map((r) => ({
 				id: r.id,
-				title: r.title,
+				title: r.dcTitle || r.title || '',
+				description: r.dcAbstract || '',
 				isVisible: r.isVisible,
 				pubNum: r.pubNum,
 				thumbnailUrl: r.thumbnailFile ? pb.files.getURL(r, r.thumbnailFile, { thumb: '80x80' }) : ''
@@ -96,6 +115,18 @@
 			return;
 		}
 		expandedId = collectionId;
+		activeTab = 'details';
+
+		// Populate edit form
+		const col = collections.find((c) => c.id === collectionId);
+		if (col) {
+			editTitle = col.title;
+			editDescription = col.description;
+			editIsVisible = col.isVisible;
+			editThumbnailFile = null;
+			editThumbnailPreview = col.thumbnailUrl;
+		}
+
 		await loadMembers(collectionId);
 	}
 
@@ -119,6 +150,93 @@
 			members = [];
 		} finally {
 			membersLoading = false;
+		}
+	}
+
+	async function saveDetails() {
+		if (!expandedId) return;
+		if (!editTitle.trim()) {
+			toast.error('Title is required');
+			return;
+		}
+		isSavingDetails = true;
+		try {
+			const formData = new FormData();
+			formData.append('title', editTitle.trim());
+			formData.append('dcTitle', editTitle.trim());
+			formData.append('dcAbstract', editDescription.trim());
+			formData.append('isVisible', String(editIsVisible));
+
+			if (editThumbnailFile) {
+				formData.append('thumbnailFile', editThumbnailFile);
+			}
+
+			await pb.collection('collections').update(expandedId, formData);
+
+			// Update local state
+			const col = collections.find((c) => c.id === expandedId);
+			if (col) {
+				col.title = editTitle.trim();
+				col.description = editDescription.trim();
+				col.isVisible = editIsVisible;
+				if (editThumbnailFile) {
+					// Reload to get new thumbnail URL
+					const updated = await pb.collection('collections').getOne(expandedId);
+					col.thumbnailUrl = updated.thumbnailFile
+						? pb.files.getURL(updated, updated.thumbnailFile, { thumb: '80x80' })
+						: '';
+					editThumbnailPreview = col.thumbnailUrl;
+				}
+				collections = [...collections];
+			}
+
+			editThumbnailFile = null;
+			toast.success('Collection updated');
+		} catch (error) {
+			console.error('Error saving collection:', error);
+			toast.error('Failed to save collection');
+		} finally {
+			isSavingDetails = false;
+		}
+	}
+
+	function handleThumbnailChange(e: Event) {
+		const input = e.currentTarget as HTMLInputElement;
+		const file = input.files?.[0];
+		if (file) {
+			editThumbnailFile = file;
+			editThumbnailPreview = URL.createObjectURL(file);
+		}
+	}
+
+	async function deleteCollection() {
+		if (!expandedId) return;
+		isDeleting = true;
+		try {
+			// Remove all collection members first
+			const memberResult = await pb.collection('collectionUsers').getList(1, 500, {
+				filter: `collection = "${expandedId}"`
+			});
+			for (const m of memberResult.items) {
+				await pb.collection('collectionUsers').delete(m.id);
+			}
+
+			await pb.collection('collections').delete(expandedId);
+
+			await logAudit('user_removed', 'collection', expandedId, authStore.user?.email || '', {
+				action: 'collection_deleted',
+				title: editTitle
+			});
+
+			expandedId = null;
+			showDeleteConfirm = false;
+			toast.success('Collection deleted');
+			await loadCollections();
+		} catch (error) {
+			console.error('Error deleting collection:', error);
+			toast.error('Failed to delete collection');
+		} finally {
+			isDeleting = false;
 		}
 	}
 
@@ -201,6 +319,37 @@
 		}
 	}
 
+	async function createCollection() {
+		if (!createTitle.trim()) {
+			toast.error('Title is required');
+			return;
+		}
+		isCreatingCollection = true;
+		try {
+			const record = await pb.collection('collections').create({
+				title: createTitle.trim(),
+				dcTitle: createTitle.trim(),
+				dcAbstract: createDescription.trim() || null,
+				isVisible: false
+			});
+
+			await logAudit('collection_created', 'collection', record.id, authStore.user?.email || '', {
+				title: createTitle.trim()
+			});
+
+			showCreateModal = false;
+			createTitle = '';
+			createDescription = '';
+			toast.success('Collection created');
+			await loadCollections();
+		} catch (error) {
+			console.error('Error creating collection:', error);
+			toast.error('Failed to create collection');
+		} finally {
+			isCreatingCollection = false;
+		}
+	}
+
 	function availableUsers(): AppUser[] {
 		const existingIds = new Set(members.map((m) => m.userId));
 		return allUsers.filter((u) => !existingIds.has(u.id));
@@ -208,11 +357,20 @@
 </script>
 
 <div id="admin-collections-page" class="mx-auto max-w-6xl">
-	<div class="mb-8">
-		<h1 class="text-3xl font-bold">Collection Management</h1>
-		<p class="mt-2 text-base-content/60">
-			Manage collection members and their roles. {collections.length} collections.
-		</p>
+	<div class="mb-8 flex items-start justify-between">
+		<div>
+			<h1 class="text-3xl font-bold">Collection Management</h1>
+			<p class="mt-2 text-base-content/60">
+				Manage collections, their details, and members. {collections.length} collections.
+			</p>
+		</div>
+		<button
+			id="create-collection-btn"
+			class="btn btn-primary"
+			onclick={() => (showCreateModal = true)}
+		>
+			+ Create Collection
+		</button>
 	</div>
 
 	<div class="mb-6">
@@ -285,103 +443,243 @@
 					</button>
 					{#if expandedId === collection.id}
 						<div class="border-t border-base-300 px-4 pt-2 pb-4">
-							{#if membersLoading}
-								<div class="flex justify-center py-4">
-									<span class="loading loading-sm loading-spinner"></span>
+							<!-- Tabs -->
+							<div class="tabs-bordered mb-4 tabs">
+								<button
+									class="tab"
+									class:tab-active={activeTab === 'details'}
+									onclick={() => (activeTab = 'details')}
+								>
+									Details
+								</button>
+								<button
+									class="tab"
+									class:tab-active={activeTab === 'members'}
+									onclick={() => (activeTab = 'members')}
+								>
+									Members ({members.length})
+								</button>
+							</div>
+
+							{#if activeTab === 'details'}
+								<!-- Details editing form -->
+								<div class="flex flex-col gap-4">
+									<div class="flex gap-6">
+										<!-- Thumbnail -->
+										<div class="flex flex-col items-center gap-2">
+											{#if editThumbnailPreview}
+												<img
+													src={editThumbnailPreview}
+													alt="Thumbnail"
+													class="size-24 rounded object-cover"
+												/>
+											{:else}
+												<div
+													class="flex size-24 items-center justify-center rounded bg-base-300 text-base-content/40"
+												>
+													<svg
+														xmlns="http://www.w3.org/2000/svg"
+														fill="none"
+														viewBox="0 0 24 24"
+														stroke-width="1.5"
+														stroke="currentColor"
+														class="size-8"
+													>
+														<path
+															stroke-linecap="round"
+															stroke-linejoin="round"
+															d="m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909M3.75 21h16.5A2.25 2.25 0 0 0 22.5 18.75V5.25A2.25 2.25 0 0 0 20.25 3H3.75A2.25 2.25 0 0 0 1.5 5.25v13.5A2.25 2.25 0 0 0 3.75 21Z"
+														/>
+													</svg>
+												</div>
+											{/if}
+											<label class="btn btn-outline btn-xs">
+												Change
+												<input
+													type="file"
+													accept="image/*"
+													class="hidden"
+													onchange={handleThumbnailChange}
+												/>
+											</label>
+										</div>
+
+										<!-- Title and description -->
+										<div class="flex flex-1 flex-col gap-3">
+											<fieldset class="fieldset">
+												<legend class="fieldset-legend">Title *</legend>
+												<input
+													id="edit-collection-title"
+													type="text"
+													class="input w-full"
+													bind:value={editTitle}
+												/>
+											</fieldset>
+
+											<fieldset class="fieldset">
+												<legend class="fieldset-legend">Description</legend>
+												<textarea
+													id="edit-collection-description"
+													class="textarea w-full"
+													rows="3"
+													bind:value={editDescription}
+												></textarea>
+											</fieldset>
+										</div>
+									</div>
+
+									<fieldset class="fieldset">
+										<legend class="fieldset-legend">Visibility</legend>
+										<label
+											id="edit-collection-visibility"
+											class="flex cursor-pointer items-center gap-3"
+										>
+											<input type="checkbox" class="checkbox" bind:checked={editIsVisible} />
+											<span>Visible to public</span>
+										</label>
+									</fieldset>
+
+									<div class="flex items-center justify-between">
+										<button
+											class="btn btn-sm btn-primary"
+											onclick={saveDetails}
+											disabled={isSavingDetails}
+										>
+											{#if isSavingDetails}
+												<span class="loading loading-xs loading-spinner"></span>
+											{/if}
+											Save Changes
+										</button>
+
+										{#if showDeleteConfirm}
+											<div class="flex items-center gap-2">
+												<span class="text-sm text-error">Delete this collection?</span>
+												<button
+													class="btn btn-sm btn-error"
+													onclick={deleteCollection}
+													disabled={isDeleting}
+												>
+													{#if isDeleting}
+														<span class="loading loading-xs loading-spinner"></span>
+													{/if}
+													Confirm
+												</button>
+												<button
+													class="btn btn-ghost btn-sm"
+													onclick={() => (showDeleteConfirm = false)}
+												>
+													Cancel
+												</button>
+											</div>
+										{:else}
+											<button
+												class="btn text-error btn-ghost btn-sm"
+												onclick={() => (showDeleteConfirm = true)}
+											>
+												Delete Collection
+											</button>
+										{/if}
+									</div>
 								</div>
-							{:else}
-								<!-- Members table -->
-								{#if members.length > 0}
-									<div class="overflow-x-auto">
-										<table class="table table-sm">
-											<thead>
-												<tr>
-													<th>User</th>
-													<th>Email</th>
-													<th>Role</th>
-													<th>Actions</th>
-												</tr>
-											</thead>
-											<tbody>
-												{#each members as member (member.id)}
-													<tr>
-														<td class="font-medium">{member.nickname || '—'}</td>
-														<td class="text-base-content/70">{member.email}</td>
-														<td>
-															<select
-																class="select-bordered select w-36 select-sm"
-																value={member.role}
-																onchange={(e) =>
-																	updateMemberRole(
-																		member.id,
-																		e.currentTarget.value as CollectionRole
-																	)}
-																disabled={savingMemberId === member.id}
-															>
-																{#each collectionRoleValues as rv (rv)}
-																	<option value={rv} selected={member.role === rv}>
-																		{COLLECTION_ROLE_LABELS[rv]}
-																	</option>
-																{/each}
-															</select>
-														</td>
-														<td>
-															<button
-																class="btn text-error btn-ghost btn-sm"
-																onclick={() => removeMember(member.id)}
-															>
-																Remove
-															</button>
-														</td>
-													</tr>
-												{/each}
-											</tbody>
-										</table>
+							{:else if activeTab === 'members'}
+								{#if membersLoading}
+									<div class="flex justify-center py-4">
+										<span class="loading loading-sm loading-spinner"></span>
 									</div>
 								{:else}
-									<p class="py-2 text-base-content/60">No members assigned.</p>
-								{/if}
+									<!-- Members table -->
+									{#if members.length > 0}
+										<div class="overflow-x-auto">
+											<table class="table table-sm">
+												<thead>
+													<tr>
+														<th>User</th>
+														<th>Email</th>
+														<th>Role</th>
+														<th>Actions</th>
+													</tr>
+												</thead>
+												<tbody>
+													{#each members as member (member.id)}
+														<tr>
+															<td class="font-medium">{member.nickname || '—'}</td>
+															<td class="text-base-content/70">{member.email}</td>
+															<td>
+																<select
+																	class="select-bordered select w-36 select-sm"
+																	value={member.role}
+																	onchange={(e) =>
+																		updateMemberRole(
+																			member.id,
+																			e.currentTarget.value as CollectionRole
+																		)}
+																	disabled={savingMemberId === member.id}
+																>
+																	{#each collectionRoleValues as rv (rv)}
+																		<option value={rv} selected={member.role === rv}>
+																			{COLLECTION_ROLE_LABELS[rv]}
+																		</option>
+																	{/each}
+																</select>
+															</td>
+															<td>
+																<button
+																	class="btn text-error btn-ghost btn-sm"
+																	onclick={() => removeMember(member.id)}
+																>
+																	Remove
+																</button>
+															</td>
+														</tr>
+													{/each}
+												</tbody>
+											</table>
+										</div>
+									{:else}
+										<p class="py-2 text-base-content/60">No members assigned.</p>
+									{/if}
 
-								<!-- Add member form -->
-								<div class="mt-4 flex flex-wrap items-end gap-2 border-t border-base-300 pt-4">
-									<div class="form-control">
-										<label class="label" for="add-user-{collection.id}">
-											<span class="label-text">User</span>
-										</label>
-										<UserSearchSelect
-											users={availableUsers()}
-											bind:value={addUserId}
-											id="add-user-{collection.id}"
-											placeholder="Search user..."
-										/>
-									</div>
-									<div class="form-control">
-										<label class="label" for="add-role-{collection.id}">
-											<span class="label-text">Role</span>
-										</label>
-										<select
-											id="add-role-{collection.id}"
-											class="select-bordered select w-36 select-sm"
-											bind:value={addRole}
+									<!-- Add member form -->
+									<div class="mt-4 flex flex-wrap items-end gap-2 border-t border-base-300 pt-4">
+										<div class="form-control">
+											<label class="label" for="add-user-{collection.id}">
+												<span class="label-text">User</span>
+											</label>
+											<UserSearchSelect
+												users={availableUsers()}
+												bind:value={addUserId}
+												id="add-user-{collection.id}"
+												placeholder="Search user..."
+											/>
+										</div>
+										<div class="form-control">
+											<label class="label" for="add-role-{collection.id}">
+												<span class="label-text">Role</span>
+											</label>
+											<select
+												id="add-role-{collection.id}"
+												class="select-bordered select w-36 select-sm"
+												bind:value={addRole}
+											>
+												{#each collectionRoleValues as rv (rv)}
+													<option value={rv}>
+														{COLLECTION_ROLE_LABELS[rv]}
+													</option>
+												{/each}
+											</select>
+										</div>
+										<button
+											class="btn btn-sm btn-primary"
+											onclick={addMember}
+											disabled={!addUserId || isAdding}
 										>
-											{#each collectionRoleValues as rv (rv)}
-												<option value={rv}>
-													{COLLECTION_ROLE_LABELS[rv]}
-												</option>
-											{/each}
-										</select>
+											{#if isAdding}
+												<span class="loading loading-xs loading-spinner"></span>
+											{/if}
+											Add Member
+										</button>
 									</div>
-									<button
-										class="btn btn-sm btn-primary"
-										onclick={addMember}
-										disabled={!addUserId || isAdding}
-									>
-										{#if isAdding}
-											<span class="loading loading-xs loading-spinner"></span>
-										{/if}
-										Add Member
-									</button>
-								</div>
+								{/if}
 							{/if}
 						</div>
 					{/if}
@@ -400,3 +698,52 @@
 		{/if}
 	{/if}
 </div>
+
+{#if showCreateModal}
+	<div id="create-collection-modal" class="modal-open modal">
+		<div class="modal-box">
+			<h3 class="text-lg font-bold">Create New Collection</h3>
+
+			<div class="mt-4 flex flex-col gap-3">
+				<fieldset class="fieldset">
+					<legend class="fieldset-legend">Title *</legend>
+					<input
+						id="create-collection-title"
+						type="text"
+						class="input w-full"
+						placeholder="Collection title"
+						bind:value={createTitle}
+					/>
+				</fieldset>
+
+				<fieldset class="fieldset">
+					<legend class="fieldset-legend">Description</legend>
+					<textarea
+						id="create-collection-description"
+						class="textarea w-full"
+						rows="3"
+						placeholder="Brief description (optional)"
+						bind:value={createDescription}
+					></textarea>
+				</fieldset>
+			</div>
+
+			<div class="modal-action">
+				<button
+					class="btn"
+					onclick={() => (showCreateModal = false)}
+					disabled={isCreatingCollection}
+				>
+					Cancel
+				</button>
+				<button class="btn btn-primary" onclick={createCollection} disabled={isCreatingCollection}>
+					{#if isCreatingCollection}
+						<span class="loading loading-sm loading-spinner"></span>
+					{/if}
+					Create
+				</button>
+			</div>
+		</div>
+		<button class="modal-backdrop" onclick={() => (showCreateModal = false)}>close</button>
+	</div>
+{/if}

--- a/src/routes/editions/+page.svelte
+++ b/src/routes/editions/+page.svelte
@@ -2,14 +2,17 @@
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { base } from '$app/paths';
+	import { pb } from '$lib/database/client';
+	import { authStore } from '$lib/database/stores/auth.svelte';
+	import { GlobalRole } from '$lib/types/roles';
 	import EditionCard from '$lib/components/cards/EditionCard.svelte';
 	import FilterSidebar from '$lib/components/filters/FilterSidebar.svelte';
 	import type { FilterState } from '$lib/types/collection';
-	import {
-		editionsStore,
-		fetchEditions,
-		isStale
-	} from '$lib/stores/data.store';
+	import { editionsStore, fetchEditions, isStale } from '$lib/stores/data.store';
+
+	let canCreate = $state(false);
+
+	let isAdmin = $derived(authStore.globalRole === GlobalRole.Admin);
 
 	// Reactive data from persisted store
 	let editions = $derived($editionsStore.items);
@@ -17,6 +20,20 @@
 	let isLoading = $state(true);
 
 	onMount(async () => {
+		// Check if user can create editions
+		if (isAdmin) {
+			canCreate = true;
+		} else if (authStore.isAuthenticated && authStore.appUserId) {
+			try {
+				const owned = await pb.collection('collectionUsers').getList(1, 1, {
+					filter: `userId = "${authStore.appUserId}" && role = "owner"`
+				});
+				canCreate = owned.items.length > 0;
+			} catch {
+				// Ignore - canCreate stays false
+			}
+		}
+
 		// If we have fresh cached data, skip loading
 		if (hasCachedData && !isStale($editionsStore.lastFetched)) {
 			isLoading = false;
@@ -139,12 +156,14 @@
 
 	function scrollToSelected() {
 		requestAnimationFrame(() => {
-			const selected = suggestionsElement?.querySelector(`[data-index="${selectedIndex}"]`) as HTMLElement | null;
+			const selected = suggestionsElement?.querySelector(
+				`[data-index="${selectedIndex}"]`
+			) as HTMLElement | null;
 			selected?.scrollIntoView({ block: 'nearest' });
 		});
 	}
 
-	function navigateToEdition(edition: typeof editions[0]) {
+	function navigateToEdition(edition: (typeof editions)[0]) {
 		showSuggestions = false;
 		selectedIndex = -1;
 		searchQuery = '';
@@ -195,30 +214,30 @@
 
 <!-- Drawer wrapper for mobile -->
 <div class="drawer lg:drawer-open">
-	<input
-		id="filter-drawer"
-		type="checkbox"
-		class="drawer-toggle"
-		bind:checked={drawerOpen}
-	/>
+	<input id="filter-drawer" type="checkbox" class="drawer-toggle" bind:checked={drawerOpen} />
 
 	<!-- Main content -->
 	<div class="drawer-content">
-		<div class="container mx-auto px-4 py-8 max-w-7xl">
+		<div class="container mx-auto max-w-7xl px-4 py-8">
 			<!-- Header -->
-			<div class="mb-8">
-				<h1 class="text-3xl md:text-4xl font-bold mb-2">Editions</h1>
-				<p class="text-base-content/70">
-					Browse our collection of 3D scholarly editions
-				</p>
+			<div class="mb-8 flex items-start justify-between">
+				<div>
+					<h1 class="mb-2 text-3xl font-bold md:text-4xl">Editions</h1>
+					<p class="text-base-content/70">Browse our collection of 3D scholarly editions</p>
+				</div>
+				{#if canCreate}
+					<a id="add-edition-btn" href="{base}/editions/new" class="btn btn-primary">
+						+ Add Edition
+					</a>
+				{/if}
 			</div>
 
 			<!-- Search and Filter Button (mobile) -->
-			<div class="flex gap-3 mb-6">
+			<div class="mb-6 flex gap-3">
 				<!-- Mobile filter button -->
 				<label
 					for="filter-drawer"
-					class="btn btn-outline lg:hidden flex-none"
+					class="btn flex-none btn-outline lg:hidden"
 					aria-label="Open filters"
 				>
 					<svg
@@ -237,15 +256,15 @@
 					</svg>
 					Filters
 					{#if activeFilterCount > 0}
-						<span class="badge badge-primary badge-sm">{activeFilterCount}</span>
+						<span class="badge badge-sm badge-primary">{activeFilterCount}</span>
 					{/if}
 				</label>
 
 				<!-- Search input with autocomplete -->
-				<div class="flex-1 search-container relative">
+				<div class="search-container relative flex-1">
 					<div class="relative">
 						<svg
-							class="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-base-content/50"
+							class="absolute top-1/2 left-3 h-5 w-5 -translate-y-1/2 text-base-content/50"
 							fill="none"
 							stroke="currentColor"
 							viewBox="0 0 24 24"
@@ -265,7 +284,7 @@
 							onfocus={handleFocus}
 							onkeydown={handleKeydown}
 							placeholder="Search editions..."
-							class="input input-bordered w-full pl-10 pr-10"
+							class="input-bordered input w-full pr-10 pl-10"
 							role="combobox"
 							aria-expanded={showSuggestions}
 							aria-haspopup="listbox"
@@ -276,11 +295,16 @@
 							<button
 								type="button"
 								onclick={clearSearch}
-								class="absolute right-3 top-1/2 -translate-y-1/2 btn btn-ghost btn-xs btn-circle"
+								class="btn absolute top-1/2 right-3 btn-circle -translate-y-1/2 btn-ghost btn-xs"
 								aria-label="Clear search"
 							>
 								<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+									<path
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										stroke-width="2"
+										d="M6 18L18 6M6 6l12 12"
+									/>
 								</svg>
 							</button>
 						{/if}
@@ -291,7 +315,7 @@
 						<ul
 							bind:this={suggestionsElement}
 							id="edition-suggestions"
-							class="absolute z-50 w-full mt-1 bg-base-100 rounded-box shadow-xl border border-base-300 max-h-80 overflow-y-auto"
+							class="absolute z-50 mt-1 max-h-80 w-full overflow-y-auto rounded-box border border-base-300 bg-base-100 shadow-xl"
 							role="listbox"
 						>
 							{#each suggestions as suggestion, index (suggestion.id)}
@@ -300,7 +324,9 @@
 									<button
 										type="button"
 										data-index={index}
-										class="w-full px-4 py-3 cursor-pointer transition-colors flex items-center gap-3 text-left {isSelected ? 'bg-primary text-primary-content' : 'hover:bg-base-200'}"
+										class="flex w-full cursor-pointer items-center gap-3 px-4 py-3 text-left transition-colors {isSelected
+											? 'bg-primary text-primary-content'
+											: 'hover:bg-base-200'}"
 										onclick={() => navigateToEdition(suggestion)}
 										onmouseenter={() => (selectedIndex = index)}
 									>
@@ -308,30 +334,52 @@
 											<img
 												src={suggestion.thumbnail}
 												alt=""
-												class="w-10 h-10 rounded object-cover shrink-0"
+												class="h-10 w-10 shrink-0 rounded object-cover"
 											/>
 										{:else}
-											<div class="w-10 h-10 rounded bg-base-300 flex items-center justify-center shrink-0">
-												<svg class="w-5 h-5 opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-													<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />
+											<div
+												class="flex h-10 w-10 shrink-0 items-center justify-center rounded bg-base-300"
+											>
+												<svg
+													class="h-5 w-5 opacity-50"
+													fill="none"
+													stroke="currentColor"
+													viewBox="0 0 24 24"
+												>
+													<path
+														stroke-linecap="round"
+														stroke-linejoin="round"
+														stroke-width="2"
+														d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"
+													/>
 												</svg>
 											</div>
 										{/if}
 										<div class="min-w-0 flex-1">
-											<div class="font-medium truncate">{suggestion.title}</div>
+											<div class="truncate font-medium">{suggestion.title}</div>
 											{#if suggestion.authors}
-												<div class="text-sm opacity-60 truncate">{suggestion.authors}</div>
+												<div class="truncate text-sm opacity-60">{suggestion.authors}</div>
 											{:else if suggestion.description}
-												<div class="text-sm opacity-60 truncate">{suggestion.description.slice(0, 60)}{suggestion.description.length > 60 ? '...' : ''}</div>
+												<div class="truncate text-sm opacity-60">
+													{suggestion.description.slice(0, 60)}{suggestion.description.length > 60
+														? '...'
+														: ''}
+												</div>
 											{/if}
 										</div>
 										{#if suggestion.hasPeerReview}
-											<span class="badge badge-sm {isSelected ? 'badge-primary-content' : 'badge-success'}">Peer reviewed</span>
+											<span
+												class="badge badge-sm {isSelected
+													? 'badge-primary-content'
+													: 'badge-success'}">Peer reviewed</span
+											>
 										{/if}
 									</button>
 								</li>
 							{/each}
-							<li class="px-3 py-2 text-xs text-base-content/50 border-t border-base-200 flex items-center gap-4">
+							<li
+								class="flex items-center gap-4 border-t border-base-200 px-3 py-2 text-xs text-base-content/50"
+							>
 								<span><kbd class="kbd kbd-xs">↑</kbd><kbd class="kbd kbd-xs">↓</kbd> navigate</span>
 								<span><kbd class="kbd kbd-xs">Enter</kbd> select</span>
 								<span><kbd class="kbd kbd-xs">Esc</kbd> close</span>
@@ -343,7 +391,7 @@
 
 			<!-- Results count -->
 			{#if !isLoading || hasCachedData}
-				<div class="text-sm text-base-content/70 mb-4">
+				<div class="mb-4 text-sm text-base-content/70">
 					Showing {filteredEditions.length} of {editions.length} editions
 				</div>
 			{/if}
@@ -351,7 +399,7 @@
 			<!-- Editions Grid -->
 			{#if isLoading && !hasCachedData}
 				<div
-					class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-4 xl:grid-cols-5 gap-4"
+					class="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-4 xl:grid-cols-5"
 				>
 					{#each Array(15) as _}
 						<div class="h-64 skeleton rounded-xl"></div>
@@ -359,7 +407,7 @@
 				</div>
 			{:else if filteredEditions.length > 0}
 				<div
-					class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-4 xl:grid-cols-5 gap-4"
+					class="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-4 xl:grid-cols-5"
 				>
 					{#each filteredEditions as edition (edition.id)}
 						<EditionCard {edition} />
@@ -369,7 +417,7 @@
 				<div class="flex flex-col items-center justify-center py-16 text-center">
 					<svg
 						xmlns="http://www.w3.org/2000/svg"
-						class="h-16 w-16 text-base-content/30 mb-4"
+						class="mb-4 h-16 w-16 text-base-content/30"
 						fill="none"
 						viewBox="0 0 24 24"
 						stroke="currentColor"
@@ -381,14 +429,14 @@
 							d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
 						/>
 					</svg>
-					<h3 class="text-lg font-medium mb-2">No editions found</h3>
-					<p class="text-base-content/60 max-w-md">
+					<h3 class="mb-2 text-lg font-medium">No editions found</h3>
+					<p class="max-w-md text-base-content/60">
 						No editions match your current filters. Try adjusting your search or clearing some
 						filters.
 					</p>
 					{#if activeFilterCount > 0}
 						<button
-							class="btn btn-primary btn-sm mt-4"
+							class="btn mt-4 btn-sm btn-primary"
 							onclick={() => {
 								filters = {
 									dcSubject: [],
@@ -411,11 +459,15 @@
 	<!-- Sidebar drawer -->
 	<div class="drawer-side z-40">
 		<label for="filter-drawer" aria-label="close sidebar" class="drawer-overlay"></label>
-		<div class="bg-base-100 min-h-full w-72 p-4 pt-20 lg:pt-4 border-r border-base-300">
+		<div class="min-h-full w-72 border-r border-base-300 bg-base-100 p-4 pt-20 lg:pt-4">
 			<!-- Close button for mobile -->
-			<div class="flex justify-between items-center mb-4 lg:hidden">
+			<div class="mb-4 flex items-center justify-between lg:hidden">
 				<span class="font-semibold">Filters</span>
-				<button class="btn btn-ghost btn-sm btn-circle" onclick={closeDrawer} aria-label="Close filters">
+				<button
+					class="btn btn-circle btn-ghost btn-sm"
+					onclick={closeDrawer}
+					aria-label="Close filters"
+				>
 					<svg
 						xmlns="http://www.w3.org/2000/svg"
 						class="h-5 w-5"

--- a/src/routes/editions/new/+page.svelte
+++ b/src/routes/editions/new/+page.svelte
@@ -1,0 +1,208 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { base } from '$app/paths';
+	import { pb } from '$lib/database/client';
+	import { authStore } from '$lib/database/stores/auth.svelte';
+	import { createEdition } from '$lib/database/edition-helpers';
+	import { GlobalRole } from '$lib/types/roles';
+	import { logAudit } from '$lib/utils/audit';
+	import toast from 'svelte-french-toast';
+
+	interface CollectionOption {
+		id: string;
+		title: string;
+	}
+
+	let isLoading = $state(true);
+	let isCreating = $state(false);
+	let canCreate = $state(false);
+	let isCollectionOwner = $state(false);
+
+	// Form state
+	let title = $state('');
+	let description = $state('');
+	let peerReviewRequested = $state(true);
+	let collectionId = $state('');
+	let collections = $state<CollectionOption[]>([]);
+
+	let isAdmin = $derived(authStore.globalRole === GlobalRole.Admin);
+
+	onMount(async () => {
+		if (!authStore.isAuthenticated) {
+			goto(`${base}/`);
+			return;
+		}
+
+		try {
+			if (isAdmin) {
+				canCreate = true;
+				const result = await pb.collection('collections').getList(1, 500);
+				collections = result.items.map((r) => ({ id: r.id, title: r.title }));
+			} else if (authStore.appUserId) {
+				const owned = await pb.collection('collectionUsers').getList(1, 100, {
+					filter: `userId = "${authStore.appUserId}" && role = "owner"`,
+					expand: 'collection'
+				});
+				if (owned.items.length > 0) {
+					canCreate = true;
+					isCollectionOwner = true;
+					peerReviewRequested = false;
+					collections = owned.items.map((r) => ({
+						id: r.collection,
+						title: r.expand?.collection?.title || ''
+					}));
+					if (collections.length === 1) {
+						collectionId = collections[0].id;
+					}
+				}
+			}
+
+			if (!canCreate) {
+				toast.error('You do not have permission to create editions');
+				goto(`${base}/editions`);
+				return;
+			}
+		} catch (error) {
+			console.error('Error checking permissions:', error);
+			toast.error('Failed to load page');
+			goto(`${base}/editions`);
+			return;
+		} finally {
+			isLoading = false;
+		}
+	});
+
+	async function handleCreate() {
+		if (!title.trim()) {
+			toast.error('Title is required');
+			return;
+		}
+		if (isCollectionOwner && !collectionId) {
+			toast.error('Please select a collection');
+			return;
+		}
+		if (!authStore.appUserId) {
+			toast.error('User profile not found');
+			return;
+		}
+
+		isCreating = true;
+		try {
+			const newId = await createEdition({
+				title: title.trim(),
+				description: description.trim(),
+				peerReviewRequested,
+				collectionId: collectionId || undefined,
+				creatorUserId: authStore.appUserId
+			});
+
+			await logAudit('edition_created', 'edition', newId, authStore.user?.email || '', {
+				title: title.trim(),
+				collectionId: collectionId || null,
+				peerReviewRequested
+			});
+
+			toast.success('Edition created');
+			goto(`${base}/editions/${newId}/workflow`);
+		} catch (error) {
+			console.error('Error creating edition:', error);
+			toast.error('Failed to create edition');
+		} finally {
+			isCreating = false;
+		}
+	}
+</script>
+
+{#if isLoading}
+	<div class="flex min-h-[50vh] items-center justify-center">
+		<span class="loading loading-lg loading-spinner"></span>
+	</div>
+{:else}
+	<div id="new-edition-page" class="container mx-auto max-w-2xl px-4 py-8">
+		<!-- Breadcrumbs -->
+		<div class="breadcrumbs mb-6 text-sm">
+			<ul>
+				<li><a href="{base}/editions">Editions</a></li>
+				<li>New Edition</li>
+			</ul>
+		</div>
+
+		<h1 class="mb-2 text-3xl font-bold">New Edition</h1>
+		<p class="mb-8 text-base-content/70">
+			Create a new edition draft. After creation you can flesh out the concept proposal and submit
+			it for review.
+		</p>
+
+		<div class="flex flex-col gap-4">
+			<fieldset class="fieldset">
+				<legend class="fieldset-legend">Title *</legend>
+				<input
+					id="edition-title"
+					type="text"
+					class="input w-full"
+					placeholder="Enter edition title"
+					bind:value={title}
+				/>
+			</fieldset>
+
+			<fieldset class="fieldset">
+				<legend class="fieldset-legend">Description</legend>
+				<textarea
+					id="edition-description"
+					class="textarea w-full"
+					rows="4"
+					placeholder="Brief description or abstract (optional)"
+					bind:value={description}
+				></textarea>
+			</fieldset>
+
+			<fieldset class="fieldset">
+				<legend class="fieldset-legend">Collection</legend>
+				<select id="edition-collection" class="select w-full" bind:value={collectionId}>
+					{#if !isCollectionOwner}
+						<option value="">None</option>
+					{/if}
+					{#each collections as col (col.id)}
+						<option value={col.id}>{col.title}</option>
+					{/each}
+				</select>
+				{#if isCollectionOwner}
+					<p class="mt-1 text-xs text-base-content/50">
+						Editions are created within your collection.
+					</p>
+				{/if}
+			</fieldset>
+
+			<fieldset class="fieldset">
+				<legend class="fieldset-legend">Review Process</legend>
+				<label id="edition-peer-review" class="flex cursor-pointer items-center gap-3">
+					<input type="checkbox" class="checkbox" bind:checked={peerReviewRequested} />
+					<span>Request peer review</span>
+				</label>
+				<p class="mt-1 text-xs text-base-content/50">
+					{#if peerReviewRequested}
+						The edition will go through the full peer-review pipeline before publication.
+					{:else}
+						The edition will go through editorial review only.
+					{/if}
+				</p>
+			</fieldset>
+		</div>
+
+		<div class="mt-8 flex gap-3">
+			<a href="{base}/editions" class="btn">Cancel</a>
+			<button
+				id="create-edition-btn"
+				class="btn btn-primary"
+				onclick={handleCreate}
+				disabled={isCreating}
+			>
+				{#if isCreating}
+					<span class="loading loading-sm loading-spinner"></span>
+				{/if}
+				Create Edition
+			</button>
+		</div>
+	</div>
+{/if}


### PR DESCRIPTION
## Summary
- Add `/editions/new` page for creating new editions (concept proposals)
  - Auth-guarded with permission check (Admin or Collection Owner)
  - Form: title, description, peer review toggle, collection assignment
  - Redirects to workflow page after creation
- Add "Add Edition" button on `/editions` listing page for authorized users
- Add full CRUD to admin collections page:
  - Create collection (modal with title + description)
  - Edit details (title, description, thumbnail upload, visibility toggle)
  - Delete collection (with confirmation)
  - Tabbed interface: Details | Members

## Test plan
- [ ] Log in as Admin → click "Add Edition" on /editions → fill form → verify redirect to workflow page
- [ ] Log in as Collection Owner → verify button appears, collection pre-selected
- [ ] Log in as Viewer → verify "Add Edition" button is hidden
- [ ] Navigate to /editions/new as Viewer → verify redirect
- [ ] Admin collections: create, edit (title/description/thumbnail/visibility), delete a collection