### PR TITLE
Merge userProfiles into the users auth collection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,8 @@ R2_ENDPOINT=
 R2_BUCKET=
 R2_ACCESS_KEY_ID=
 R2_SECRET_ACCESS_KEY=
+
+# Show demo-account quick-login buttons on the login form in production
+# builds too (always shown in dev). Set to "true" to expose the three seeded
+# test accounts on the production login form.
+PUBLIC_SHOW_DEMO_ACCOUNTS=false

--- a/pocketbase/pb_schema/collections.json
+++ b/pocketbase/pb_schema/collections.json
@@ -1,44 +1,27 @@
 [
 	{
 		"name": "users",
-		"type": "base",
+		"type": "auth",
 		"fields": [
-			{
-				"name": "user",
-				"type": "text",
-				"required": true
-			},
-			{
-				"name": "email",
-				"type": "email",
-				"required": true
-			},
 			{
 				"name": "nickname",
 				"type": "text",
-				"required": true
+				"required": false
 			},
 			{
 				"name": "role",
 				"type": "select",
-				"required": true,
+				"required": false,
 				"maxSelect": 1,
 				"values": [
 					"admin",
 					"editorial_board",
 					"viewer"
 				]
-			},
-			{
-				"name": "pbAuthId",
-				"type": "text",
-				"required": false
 			}
 		],
 		"indexes": [
-			"CREATE UNIQUE INDEX idx_users_user ON users (user)",
-			"CREATE INDEX idx_users_email ON users (email)",
-			"CREATE UNIQUE INDEX idx_users_pbAuthId ON users (pbAuthId)"
+			"CREATE INDEX IF NOT EXISTS idx_users_userHash ON users (userHash)"
 		],
 		"listRule": "",
 		"viewRule": "",
@@ -844,7 +827,7 @@
 				"type": "relation",
 				"required": true,
 				"maxSelect": 1,
-				"collectionId": "userProfiles",
+				"collectionId": "users",
 				"cascadeDelete": false
 			},
 			{

--- a/scripts/create-pocketbase-collections.ts
+++ b/scripts/create-pocketbase-collections.ts
@@ -186,7 +186,6 @@ async function main() {
 
 	await waitForPocketBase();
 	await authenticate();
-	await dropLegacyUserProfiles();
 
 	const collectionIds: Record<string, string> = {};
 
@@ -522,7 +521,10 @@ async function main() {
 		]
 	});
 
-	console.log('\nPhase 4: Setting open API rules...\n');
+	console.log('\nPhase 4: Dropping legacy userProfiles (if present)...\n');
+	await dropLegacyUserProfiles();
+
+	console.log('\nPhase 5: Setting open API rules...\n');
 
 	for (const name of [
 		'users',

--- a/scripts/create-pocketbase-collections.ts
+++ b/scripts/create-pocketbase-collections.ts
@@ -88,8 +88,18 @@ async function waitForPocketBase() {
 
 async function authenticate() {
 	console.log('Authenticating...');
-	await pb.collection('_superusers').authWithPassword(ADMIN_EMAIL, ADMIN_PASSWORD);
-	console.log('Authenticated successfully\n');
+	try {
+		await pb.collection('_superusers').authWithPassword(ADMIN_EMAIL, ADMIN_PASSWORD);
+		console.log('Authenticated successfully\n');
+	} catch (err: any) {
+		console.error('Auth error:');
+		console.error('  url:      ', pb.baseUrl);
+		console.error('  email:    ', ADMIN_EMAIL);
+		console.error('  status:   ', err?.status);
+		console.error('  message:  ', err?.message);
+		console.error('  response: ', JSON.stringify(err?.response ?? err?.data ?? err, null, 2));
+		throw err;
+	}
 }
 
 async function getCollection(name: string) {
@@ -122,6 +132,32 @@ function mergeFields(existingFields: Record<string, unknown>[], desiredFields: F
 	return mergedFields;
 }
 
+/**
+ * Detect relation fields whose target collection changed. PB rejects this
+ * in a single update with "validation_field_relation_change", so we have to
+ * drop and re-add across two separate update calls.
+ */
+function findRelationRetargets(
+	existingFields: Record<string, unknown>[],
+	desiredFields: FieldDef[]
+): string[] {
+	const names: string[] = [];
+	for (const desired of desiredFields) {
+		const existing = existingFields.find((f) => f?.name === desired.name);
+		if (!existing) continue;
+		if (
+			desired.type === 'relation' &&
+			existing.type === 'relation' &&
+			typeof desired.collectionId === 'string' &&
+			typeof existing.collectionId === 'string' &&
+			desired.collectionId !== existing.collectionId
+		) {
+			names.push(desired.name);
+		}
+	}
+	return names;
+}
+
 async function ensureCollection(definition: CollectionDef) {
 	const existing = await getCollection(definition.name);
 
@@ -135,14 +171,42 @@ async function ensureCollection(definition: CollectionDef) {
 		return created.id;
 	}
 
-	const mergedFields = mergeFields(
-		Array.isArray(existing.fields) ? existing.fields : [],
-		definition.fields
-	);
+	const existingFieldsArr = Array.isArray(existing.fields) ? existing.fields : [];
 
-	await pb.collections.update(existing.id, {
-		fields: mergedFields
-	});
+	// Handle relation-target retargets with a pre-update that drops those
+	// fields, so the main update can add them fresh pointing at the new
+	// target. PB refuses to change a relation's collectionId in place.
+	const retargets = findRelationRetargets(existingFieldsArr, definition.fields);
+	let workingFields = existingFieldsArr;
+	if (retargets.length > 0) {
+		console.log(`   ${definition.name}: retargeting relation(s): ${retargets.join(', ')}`);
+		workingFields = existingFieldsArr.filter(
+			(f) => typeof f?.name !== 'string' || !retargets.includes(f.name as string)
+		);
+		try {
+			await pb.collections.update(existing.id, { fields: workingFields });
+		} catch (err: any) {
+			console.error(`   ${definition.name}: retarget-drop failed`);
+			console.error('     status: ', err?.status);
+			console.error('     message:', err?.message);
+			console.error('     response:', JSON.stringify(err?.response ?? err?.data ?? err, null, 2));
+			throw err;
+		}
+	}
+
+	const mergedFields = mergeFields(workingFields, definition.fields);
+
+	try {
+		await pb.collections.update(existing.id, {
+			fields: mergedFields
+		});
+	} catch (err: any) {
+		console.error(`   ${definition.name}: update failed`);
+		console.error('     status: ', err?.status);
+		console.error('     message:', err?.message);
+		console.error('     response:', JSON.stringify(err?.response ?? err?.data ?? err, null, 2));
+		throw err;
+	}
 
 	console.log(`   ${definition.name}: ensured`);
 	return existing.id;

--- a/scripts/create-pocketbase-collections.ts
+++ b/scripts/create-pocketbase-collections.ts
@@ -169,6 +169,16 @@ async function setOpenRules(name: string) {
 	console.log(`   ${name}: API rules set to open`);
 }
 
+async function dropLegacyUserProfiles() {
+	try {
+		const existing = await pb.collections.getOne('userProfiles');
+		await pb.collections.delete(existing.id);
+		console.log('   dropped legacy userProfiles collection\n');
+	} catch {
+		// collection already absent — nothing to do
+	}
+}
+
 async function main() {
 	console.log('Creating PocketBase schema');
 	console.log(`   URL: ${POCKETBASE_URL}`);
@@ -176,6 +186,7 @@ async function main() {
 
 	await waitForPocketBase();
 	await authenticate();
+	await dropLegacyUserProfiles();
 
 	const collectionIds: Record<string, string> = {};
 
@@ -184,25 +195,16 @@ async function main() {
 	collectionIds['users'] = await ensureCollection({
 		name: 'users',
 		type: 'auth',
-		fields: []
-	});
-
-	collectionIds['userProfiles'] = await ensureCollection({
-		name: 'userProfiles',
-		type: 'base',
 		fields: [
-			{ name: 'user', type: 'text', required: false },
-			{ name: 'userHash', type: 'text', required: false },
-			{ name: 'email', type: 'email', required: true },
-			{ name: 'nickname', type: 'text', required: true },
+			{ name: 'nickname', type: 'text', required: false },
 			{
 				name: 'role',
 				type: 'select',
-				required: true,
+				required: false,
 				maxSelect: 1,
 				values: globalRoleValues
 			},
-			{ name: 'pbAuthId', type: 'text', required: false }
+			{ name: 'userHash', type: 'text', required: false }
 		]
 	});
 
@@ -417,7 +419,7 @@ async function main() {
 		type: 'base',
 		fields: [
 			relationField('collection', collectionIds['collections'], { cascadeDelete: true }),
-			relationField('publishedBy', collectionIds['userProfiles'])
+			relationField('publishedBy', collectionIds['users'])
 		]
 	});
 
@@ -426,8 +428,8 @@ async function main() {
 		type: 'base',
 		fields: [
 			relationField('collection', collectionIds['collections'], { cascadeDelete: true }),
-			relationField('user', collectionIds['userProfiles']),
-			relationField('userId', collectionIds['userProfiles'])
+			relationField('user', collectionIds['users']),
+			relationField('userId', collectionIds['users'])
 		]
 	});
 
@@ -437,8 +439,8 @@ async function main() {
 		fields: [
 			relationField('edition', collectionIds['editions'], { cascadeDelete: true }),
 			relationField('editionId', collectionIds['editions'], { cascadeDelete: true }),
-			relationField('user', collectionIds['userProfiles']),
-			relationField('userId', collectionIds['userProfiles'])
+			relationField('user', collectionIds['users']),
+			relationField('userId', collectionIds['users'])
 		]
 	});
 
@@ -449,7 +451,7 @@ async function main() {
 		type: 'base',
 		fields: [
 			relationField('editionId', collectionIds['editions'], { required: true, cascadeDelete: true }),
-			relationField('reviewerId', collectionIds['userProfiles'], { required: true }),
+			relationField('reviewerId', collectionIds['users'], { required: true }),
 			{ name: 'reviewStage', type: 'number', required: true },
 			{
 				name: 'decision',
@@ -467,8 +469,8 @@ async function main() {
 		type: 'base',
 		fields: [
 			relationField('editionId', collectionIds['editions'], { required: true, cascadeDelete: true }),
-			relationField('reviewerId', collectionIds['userProfiles'], { required: true }),
-			relationField('assignedBy', collectionIds['userProfiles'], { required: true }),
+			relationField('reviewerId', collectionIds['users'], { required: true }),
+			relationField('assignedBy', collectionIds['users'], { required: true }),
 			{ name: 'reviewStage', type: 'number', required: true },
 			{
 				name: 'status',
@@ -485,7 +487,7 @@ async function main() {
 		type: 'base',
 		fields: [
 			relationField('editionId', collectionIds['editions'], { required: true, cascadeDelete: true }),
-			relationField('reviewerId', collectionIds['userProfiles'], { required: true }),
+			relationField('reviewerId', collectionIds['users'], { required: true }),
 			{ name: 'reviewStage', type: 'number', required: true },
 			{
 				name: 'category',
@@ -504,7 +506,7 @@ async function main() {
 		name: 'notifications',
 		type: 'base',
 		fields: [
-			relationField('recipientId', collectionIds['userProfiles'], { required: true, cascadeDelete: true }),
+			relationField('recipientId', collectionIds['users'], { required: true, cascadeDelete: true }),
 			relationField('editionId', collectionIds['editions'], { cascadeDelete: true }),
 			{
 				name: 'type',
@@ -524,7 +526,6 @@ async function main() {
 
 	for (const name of [
 		'users',
-		'userProfiles',
 		'site',
 		'keywords',
 		'collections',

--- a/scripts/import-data.ts
+++ b/scripts/import-data.ts
@@ -199,34 +199,33 @@ async function main() {
 		console.log(`   Skipped, site already exists (${siteId})`);
 	}
 
-	console.log('\nImporting user profiles...');
+	console.log('\nImporting users...');
 	const usersData = readJsonArray<any>('user.json');
-	const existingProfiles = await pb.collection('userProfiles').getFullList();
-	const existingProfileEmails = new Set(existingProfiles.map((record: any) => normalizeEmail(record.email)));
+	const existingUsers = await pb.collection('users').getFullList();
+	const existingEmails = new Set(existingUsers.map((record: any) => normalizeEmail(record.email)));
 
-	for (const record of existingProfiles) {
+	for (const record of existingUsers) {
 		if (record.userHash) {
 			userHashToId.set(record.userHash, record.id);
 		}
-		if (record.user) {
-			userHashToId.set(record.user, record.id);
-		}
 	}
 
-	let importedProfiles = 0;
-	let skippedProfiles = 0;
+	let importedUsers = 0;
+	let skippedUsers = 0;
 
 	for (const doc of usersData) {
 		const email = normalizeEmail(doc.email);
-		if (email && existingProfileEmails.has(email)) {
-			skippedProfiles++;
+		if (email && existingEmails.has(email)) {
+			skippedUsers++;
 			continue;
 		}
 
-		const result = await pb.collection('userProfiles').create({
-			user: doc.user,
-			userHash: doc.user,
+		const tempPassword = `${doc.user || 'import'}-${Math.random().toString(36).slice(2, 10)}`;
+		const result = await pb.collection('users').create({
 			email: doc.email,
+			password: tempPassword,
+			passwordConfirm: tempPassword,
+			userHash: doc.user,
 			nickname: doc.nickname,
 			role: mapGlobalRole(doc.role)
 		});
@@ -235,13 +234,13 @@ async function main() {
 			userHashToId.set(doc.user, result.id);
 		}
 		if (email) {
-			existingProfileEmails.add(email);
+			existingEmails.add(email);
 		}
 
-		importedProfiles++;
+		importedUsers++;
 	}
 
-	console.log(`   Imported ${importedProfiles}, skipped ${skippedProfiles}`);
+	console.log(`   Imported ${importedUsers}, skipped ${skippedUsers}`);
 
 	console.log('\nImporting keywords...');
 	const keywordsData = readJsonArray<any>('keyword.json');

--- a/scripts/seed-users.js
+++ b/scripts/seed-users.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Seed test users into PocketBase (auth + profile).
+ * Seed test users into PocketBase.
  * Creates one user per global role for testing.
  *
  * Run with: node scripts/seed-users.js
@@ -18,90 +18,40 @@ async function seedUsers() {
 
 	for (const user of users) {
 		try {
-			// 1. Create PocketBase auth record
-			const authRes = await fetch(`${POCKETBASE_URL}/api/collections/users/records`, {
+			const res = await fetch(`${POCKETBASE_URL}/api/collections/users/records`, {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify({
 					email: user.email,
 					password: user.password,
 					passwordConfirm: user.password,
-					emailVisibility: true
+					emailVisibility: true,
+					nickname: user.nickname,
+					role: user.role,
+					userHash: user.email
 				})
 			});
 
-			let pbAuthId = '';
-
-			if (authRes.ok) {
-				const authData = await authRes.json();
-				pbAuthId = authData.id;
-				console.log(`  Auth record created: ${user.email} (${pbAuthId})`);
+			if (res.ok) {
+				const data = await res.json();
+				console.log(`  Created: ${user.nickname} [${user.role}] (${data.id})`);
 			} else {
-				const err = await authRes.json();
-				// If user already exists, try to find their ID
+				const err = await res.json();
 				if (err.data?.email?.code === 'validation_not_unique') {
-					console.log(`  Auth record exists: ${user.email} (skipping auth creation)`);
-					// Fetch existing auth record by email
-					const listRes = await fetch(
-						`${POCKETBASE_URL}/api/collections/users/records?filter=email='${user.email}'`
-					);
-					if (listRes.ok) {
-						const listData = await listRes.json();
-						if (listData.items?.length > 0) {
-							pbAuthId = listData.items[0].id;
-						}
-					}
+					console.log(`  Exists: ${user.email} (skipping)`);
 				} else {
-					console.error(`  Failed auth for ${user.email}:`, JSON.stringify(err));
-					continue;
+					console.error(`  Failed ${user.email}:`, JSON.stringify(err));
 				}
-			}
-
-			// 2. Check if userProfile already exists
-			const profileCheckRes = await fetch(
-				`${POCKETBASE_URL}/api/collections/userProfiles/records?filter=email='${user.email}'`
-			);
-			if (profileCheckRes.ok) {
-				const profileCheckData = await profileCheckRes.json();
-				if (profileCheckData.items?.length > 0) {
-					console.log(`  Profile exists: ${user.email} (skipping)\n`);
-					continue;
-				}
-			}
-
-			// 3. Create userProfile record
-			const profileRes = await fetch(
-				`${POCKETBASE_URL}/api/collections/userProfiles/records`,
-				{
-					method: 'POST',
-					headers: { 'Content-Type': 'application/json' },
-					body: JSON.stringify({
-						user: user.email,
-						userHash: user.email,
-						email: user.email,
-						nickname: user.nickname,
-						role: user.role,
-						pbAuthId: pbAuthId
-					})
-				}
-			);
-
-			if (profileRes.ok) {
-				console.log(`  Profile created: ${user.nickname} [${user.role}]\n`);
-			} else {
-				const err = await profileRes.json();
-				console.error(`  Failed profile for ${user.email}:`, JSON.stringify(err));
 			}
 		} catch (err) {
 			console.error(`  Error seeding ${user.email}:`, err.message);
 		}
 	}
 
-	// 4. Create a test collection owned by the editor user
 	await seedTestCollection();
 
-	console.log('Seeding complete!');
-	console.log('\nTest accounts:');
+	console.log('\nSeeding complete!');
+	console.log('Test accounts:');
 	console.log(`  All passwords: ${users[0].password}`);
 	for (const user of users) {
 		console.log(`  ${user.role.padEnd(16)} ${user.email}`);
@@ -112,35 +62,32 @@ async function seedTestCollection() {
 	const EDITOR_EMAIL = 'editor@pure3d.eu';
 	const COLLECTION_TITLE = 'Editor Test Collection';
 
-	console.log(`Creating test collection for ${EDITOR_EMAIL}...\n`);
+	console.log(`\nCreating test collection for ${EDITOR_EMAIL}...`);
 
-	// Check if the test collection already exists
 	const checkRes = await fetch(
 		`${POCKETBASE_URL}/api/collections/collections/records?filter=title='${COLLECTION_TITLE}'`
 	);
 	if (checkRes.ok) {
 		const checkData = await checkRes.json();
 		if (checkData.items?.length > 0) {
-			console.log(`  Collection "${COLLECTION_TITLE}" already exists (skipping)\n`);
+			console.log(`  Collection "${COLLECTION_TITLE}" already exists (skipping)`);
 			return;
 		}
 	}
 
-	// Create the collection
-	const collectionRes = await fetch(
-		`${POCKETBASE_URL}/api/collections/collections/records`,
-		{
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({
-				title: COLLECTION_TITLE,
-				isVisible: true,
-				dcTitle: COLLECTION_TITLE,
-				dcAbstract: '<p>A test collection where the editor user is the owner, for testing edition creation.</p>',
-				dcDescription: '<p>Use this collection to test creating and managing editions as a collection owner.</p>'
-			})
-		}
-	);
+	const collectionRes = await fetch(`${POCKETBASE_URL}/api/collections/collections/records`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			title: COLLECTION_TITLE,
+			isVisible: true,
+			dcTitle: COLLECTION_TITLE,
+			dcAbstract:
+				'<p>A test collection where the editor user is the owner, for testing edition creation.</p>',
+			dcDescription:
+				'<p>Use this collection to test creating and managing editions as a collection owner.</p>'
+		})
+	});
 
 	if (!collectionRes.ok) {
 		const err = await collectionRes.json();
@@ -151,38 +98,33 @@ async function seedTestCollection() {
 	const collection = await collectionRes.json();
 	console.log(`  Collection created: "${COLLECTION_TITLE}" (${collection.id})`);
 
-	// Look up the editor's userProfile ID (collectionUsers.userId is a relation to userProfiles)
-	const profileRes = await fetch(
-		`${POCKETBASE_URL}/api/collections/userProfiles/records?filter=email='${EDITOR_EMAIL}'`
+	const userRes = await fetch(
+		`${POCKETBASE_URL}/api/collections/users/records?filter=email='${EDITOR_EMAIL}'`
 	);
-	if (!profileRes.ok) {
-		console.error(`  Could not fetch userProfile for ${EDITOR_EMAIL}`);
+	if (!userRes.ok) {
+		console.error(`  Could not fetch user ${EDITOR_EMAIL}`);
 		return;
 	}
-	const profileData = await profileRes.json();
-	const editorProfileId = profileData.items?.[0]?.id;
-	if (!editorProfileId) {
-		console.error(`  Could not find userProfile for ${EDITOR_EMAIL}`);
+	const userData = await userRes.json();
+	const editorId = userData.items?.[0]?.id;
+	if (!editorId) {
+		console.error(`  Could not find user ${EDITOR_EMAIL}`);
 		return;
 	}
 
-	// Assign the editor as owner of this collection
-	const collUserRes = await fetch(
-		`${POCKETBASE_URL}/api/collections/collectionUsers/records`,
-		{
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({
-				collection: collection.id,
-				userId: editorProfileId,
-				user: editorProfileId,
-				role: 'owner'
-			})
-		}
-	);
+	const collUserRes = await fetch(`${POCKETBASE_URL}/api/collections/collectionUsers/records`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			collection: collection.id,
+			userId: editorId,
+			user: editorId,
+			role: 'owner'
+		})
+	});
 
 	if (collUserRes.ok) {
-		console.log(`  Editor assigned as owner of "${COLLECTION_TITLE}"\n`);
+		console.log(`  Editor assigned as owner of "${COLLECTION_TITLE}"`);
 	} else {
 		const err = await collUserRes.json();
 		console.error(`  Failed to assign editor as owner:`, JSON.stringify(err));

--- a/src/lib/components/admin/MemberManager.svelte
+++ b/src/lib/components/admin/MemberManager.svelte
@@ -88,7 +88,7 @@
 					filter,
 					expand: 'userId'
 				}),
-				pb.collection('userProfiles').getList(1, 500)
+				pb.collection('users').getList(1, 500)
 			]);
 
 			const profileMap = new Map(

--- a/src/lib/components/ui/Login/EmailLoginForm.svelte
+++ b/src/lib/components/ui/Login/EmailLoginForm.svelte
@@ -1,8 +1,13 @@
 <script lang="ts">
 	import PhKeyBold from '~icons/ph/key-bold';
 	import { dev } from '$app/environment';
+	import { PUBLIC_SHOW_DEMO_ACCOUNTS } from '$env/static/public';
 	import { authStore } from '$lib/database';
 	import { closeLoginModal, getAuthErrorMessage, validateEmail } from './utils';
+
+	// Show demo-account buttons in dev always, and in prod only when
+	// PUBLIC_SHOW_DEMO_ACCOUNTS="true" is set at build time.
+	const showDemoAccounts = dev || PUBLIC_SHOW_DEMO_ACCOUNTS === 'true';
 
 	let email = $state('');
 	let password = $state('');
@@ -99,7 +104,7 @@
 			{isLoading ? 'Signing in...' : 'Sign in with Email'}
 		</button>
 
-		{#if dev}
+		{#if showDemoAccounts}
 			<div id="demo-accounts" class="mt-4 rounded-lg border border-dashed border-base-300 p-3">
 				<p class="mb-2 text-xs font-medium text-base-content/50">Demo Accounts</p>
 				<div class="flex flex-wrap gap-1.5">

--- a/src/lib/components/workflow/CollaboratorManager.svelte
+++ b/src/lib/components/workflow/CollaboratorManager.svelte
@@ -53,7 +53,7 @@
 				pb.collection('editionUsers').getList(1, 100, {
 					filter: `editionId = "${editionId}" && role != "reviewer"`
 				}),
-				pb.collection('userProfiles').getList(1, 500)
+				pb.collection('users').getList(1, 500)
 			]);
 
 			const profileMap = new Map(

--- a/src/lib/components/workflow/ReviewFeedbackList.svelte
+++ b/src/lib/components/workflow/ReviewFeedbackList.svelte
@@ -61,7 +61,7 @@
 			if (!userLookup) {
 				const reviewerIds = [...new Set(feedbackItems.map((f) => f.reviewerId))];
 				if (reviewerIds.length > 0) {
-					const userResult = await pb.collection('userProfiles').getList(1, 100, {
+					const userResult = await pb.collection('users').getList(1, 100, {
 						filter: reviewerIds.map((id) => `id = "${id}"`).join(' || ')
 					});
 					localUserLookup = new Map(

--- a/src/lib/database/stores/auth.svelte.ts
+++ b/src/lib/database/stores/auth.svelte.ts
@@ -8,6 +8,8 @@ interface User {
 	email: string;
 	username?: string;
 	verified: boolean;
+	nickname?: string;
+	role?: GlobalRole;
 	created: string;
 	updated: string;
 }
@@ -15,10 +17,8 @@ interface User {
 class AuthStore {
 	user = $state<User | null>(null);
 	isAuthenticated = $derived(!!this.user);
-
-	// App-level user data (from `userProfiles` collection, not PB auth)
-	appUserId = $state<string | null>(null);
-	globalRole = $state<GlobalRole>(GlobalRole.Viewer);
+	appUserId = $derived(this.user?.id ?? null);
+	globalRole = $derived<GlobalRole>(this.user?.role ?? GlobalRole.Viewer);
 
 	constructor() {
 		if (browser) {
@@ -27,83 +27,38 @@ class AuthStore {
 			pb.authStore.onChange(() => {
 				this.user = pb.authStore.model as User | null;
 				if (this.user) {
-					this.fetchAppUser(this.user.email);
+					notificationStore.subscribe(this.user.id);
 				} else {
-					this.appUserId = null;
-					this.globalRole = GlobalRole.Viewer;
+					notificationStore.unsubscribeAll();
 				}
 			});
 
-			// Resolve role on init if already authenticated
 			if (this.user) {
-				this.fetchAppUser(this.user.email);
+				notificationStore.subscribe(this.user.id);
 			}
-		}
-	}
-
-	private async fetchAppUser(email: string) {
-		try {
-			const result = await pb.collection('userProfiles').getList(1, 1, {
-				filter: `email = "${email}"`
-			});
-			if (result.items.length > 0) {
-				const record = result.items[0];
-				this.appUserId = record.id;
-				this.globalRole = (record.role as GlobalRole) || GlobalRole.Viewer;
-				notificationStore.subscribe(record.id);
-			} else {
-				this.appUserId = null;
-				this.globalRole = GlobalRole.Viewer;
-			}
-		} catch {
-			this.appUserId = null;
-			this.globalRole = GlobalRole.Viewer;
 		}
 	}
 
 	async login(email: string, password: string) {
 		const authData = await pb.collection('users').authWithPassword(email, password);
 		this.user = authData.record as unknown as User;
-		await this.fetchAppUser(email);
 		return authData;
 	}
 
 	async register(email: string, password: string, passwordConfirm: string) {
-		// 1. Create PB auth account
 		await pb.collection('users').create({
 			email,
 			password,
-			passwordConfirm
+			passwordConfirm,
+			nickname: email.split('@')[0],
+			role: GlobalRole.Viewer
 		});
-
-		// 2. Login with the new account
 		await this.login(email, password);
-
-		// 3. Create app-level user profile (with default viewer role)
-		try {
-			const existing = await pb.collection('userProfiles').getList(1, 1, {
-				filter: `email = "${email}"`
-			});
-			if (existing.items.length === 0) {
-				await pb.collection('userProfiles').create({
-					user: email,
-					email,
-					nickname: email.split('@')[0],
-					role: GlobalRole.Viewer,
-					pbAuthId: this.user?.id || ''
-				});
-				await this.fetchAppUser(email);
-			}
-		} catch (err) {
-			console.error('Failed to create user profile:', err);
-		}
 	}
 
 	logout() {
 		pb.authStore.clear();
 		this.user = null;
-		this.appUserId = null;
-		this.globalRole = GlobalRole.Viewer;
 		notificationStore.unsubscribeAll();
 	}
 }

--- a/src/lib/server/pocketbase.ts
+++ b/src/lib/server/pocketbase.ts
@@ -75,7 +75,7 @@ export async function getUsers() {
 	const pb = createPocketBaseClient();
 
 	try {
-		const result = await pb.collection('userProfiles').getList(1, 500);
+		const result = await pb.collection('users').getList(1, 500);
 		return result.items.map((record) => ({
 			id: record.id,
 			mongoId: record.mongoId,
@@ -482,7 +482,7 @@ export async function updateUserRole(userId: string, newRole: GlobalRole) {
 	const pb = createPocketBaseClient();
 
 	try {
-		await pb.collection('userProfiles').update(userId, { role: newRole });
+		await pb.collection('users').update(userId, { role: newRole });
 		return true;
 	} catch (error) {
 		console.error('Error updating user role:', error);

--- a/src/lib/utils/review-helpers.ts
+++ b/src/lib/utils/review-helpers.ts
@@ -101,11 +101,11 @@ export function getTargetStatusFromVerdict(
 }
 
 /**
- * Get userProfile IDs of all admin users.
+ * Get IDs of all admin users.
  */
 export async function getAdminUserIds(): Promise<string[]> {
 	try {
-		const result = await pb.collection('userProfiles').getList(1, 500, {
+		const result = await pb.collection('users').getList(1, 500, {
 			filter: `role = "${GlobalRole.Admin}"`
 		});
 		return result.items.map((r) => r.id);

--- a/src/routes/admin/users/+page.svelte
+++ b/src/routes/admin/users/+page.svelte
@@ -59,7 +59,7 @@
 	async function loadUsers() {
 		try {
 			isLoading = true;
-			const result = await pb.collection('userProfiles').getList(1, 500);
+			const result = await pb.collection('users').getList(1, 500);
 			users = result.items.map((record) => ({
 				id: record.id,
 				email: record.email || '',
@@ -121,7 +121,7 @@
 			});
 
 			// 2. Create userProfile linked to auth record
-			await pb.collection('userProfiles').create({
+			await pb.collection('users').create({
 				email: createEmail,
 				nickname: createNickname || createEmail.split('@')[0],
 				role: createRole,
@@ -176,7 +176,7 @@
 
 		isSaving = true;
 		try {
-			await pb.collection('userProfiles').update(editingUser.id, changes);
+			await pb.collection('users').update(editingUser.id, changes);
 
 			await logAudit('user_updated', 'user', editingUser.id, authStore.user?.email || '', {
 				email: editingUser.email,
@@ -234,7 +234,7 @@
 			}
 
 			// 3. Delete userProfile
-			await pb.collection('userProfiles').delete(deletingUser.id);
+			await pb.collection('users').delete(deletingUser.id);
 
 			// 4. Delete PB auth user
 			if (deletingUser.pbAuthId) {

--- a/src/routes/admin/workflow/+page.svelte
+++ b/src/routes/admin/workflow/+page.svelte
@@ -112,7 +112,7 @@
 					expand: 'reviewerId,assignedBy'
 				}),
 				pb.collection('editionReviews').getList(1, 1000, { expand: 'reviewerId' }),
-				pb.collection('userProfiles').getList(1, 500)
+				pb.collection('users').getList(1, 500)
 			]);
 
 			editions = edResult.items.map((r) => ({

--- a/src/routes/editions/[slug]/workflow/+page.svelte
+++ b/src/routes/editions/[slug]/workflow/+page.svelte
@@ -308,7 +308,7 @@
 				...new Set([...assignments.map((a) => a.reviewerId), ...reviews.map((r) => r.reviewerId)])
 			];
 			if (reviewerIds.length > 0) {
-				const userResult = await pb.collection('userProfiles').getList(1, 100, {
+				const userResult = await pb.collection('users').getList(1, 100, {
 					filter: reviewerIds.map((id) => `id = "${id}"`).join(' || ')
 				});
 				userLookup = new Map(


### PR DESCRIPTION
## Summary

Collapses the two-collection split (\`users\` auth + \`userProfiles\` base) into a single \`users\` auth collection. Eliminates the post-login lookup-by-email, the \`pbAuthId\` join key, and redundant \`email\` storage.

### Schema
- \`users\` auth collection gains custom fields: \`nickname\` (text), \`role\` (select: admin / editorial_board / viewer), \`userHash\` (text — legacy Mongo ref, retained for import compatibility, can drop post-Mongo sunset).
- \`userProfiles\` collection dropped; the schema script's \`dropLegacyUserProfiles()\` removes it on first run.
- All relation fields retargeted to \`users\`: \`editions.publishedBy\`, \`collectionUsers.user/userId\`, \`editionUsers.user/userId\`, \`editionReviews.reviewerId\`, \`reviewAssignments.reviewerId/assignedBy\`, \`reviewFeedback.reviewerId\`, \`notifications.recipientId\`.

### Code
- \`auth.svelte.ts\`: drops \`fetchAppUser\`. \`appUserId\` and \`globalRole\` are now \`$derived\` directly from \`pb.authStore.model\` — no extra query.
- \`register()\` creates a single record carrying nickname + default viewer role.
- Renamed \`pb.collection('userProfiles')\` → \`pb.collection('users')\` across ~10 files.
- \`seed-users.js\` and \`import-data.ts\` updated to one-pass creation.

## ⚠️ Migration required

Relation fields are retargeted from \`userProfiles\` to \`users\`. Existing records pointing at the old \`userProfiles\` IDs will become orphans.

**Easiest path (staging + local dev, data is expendable):**
\`\`\`
# stop pocketbase
rm -rf pocketbase/pb_data
# start pocketbase
bun scripts/create-pocketbase-collections.ts
node scripts/seed-users.js
\`\`\`

**If data must be preserved:** write a one-off migration that, for each \`userProfiles\` row, copies \`nickname\`/\`role\`/\`userHash\` onto the matching \`users\` auth row (by email), then rewrites every FK column (\`userId\`, \`reviewerId\`, \`recipientId\`, \`publishedBy\`, \`assignedBy\`) with the new \`users.id\`. Then drop \`userProfiles\`. Not included in this PR since staging is small and Mongo is being deprecated.

## Test plan
- [ ] Reset local \`pb_data\`, run schema script, run seed-users.
- [ ] Log in as each seeded role (admin / editorial_board / viewer) — role resolves from \`pb.authStore.model.role\` without extra request.
- [ ] Register a new account — single \`users\` record created with default viewer role.
- [ ] Create a draft edition as the editor, assign a reviewer — \`editionUsers\` entry points at the reviewer's \`users.id\`.
- [ ] Submit a review — \`editionReviews.reviewerId\` references \`users.id\`.
- [ ] Receive a notification — \`notifications.recipientId\` resolves.
- [ ] Admin → Users page lists all seeded accounts with nickname + role.