### PR TITLE
feat: voyager viewer modes — classic, expert, standalone

### DIFF
--- a/src/lib/components/voyager/VoyagerViewer.svelte
+++ b/src/lib/components/voyager/VoyagerViewer.svelte
@@ -17,6 +17,7 @@
 
 	import { onMount } from 'svelte';
 	import toast from 'svelte-french-toast';
+	import { type ViewerMode, DEFAULT_VIEWER_MODE } from '$lib/types/roles';
 
 	interface Props {
 		/** URL for iframe mode OR root path for direct mode */
@@ -40,6 +41,8 @@
 		title: string;
 		/** Use direct embedding instead of iframe */
 		direct?: boolean;
+		/** Viewer mode — controls UI complexity. Classic=minimal, Expert=full controls, Standalone=expert+menu+editor */
+		mode?: ViewerMode;
 		/** Show control toolbar (only available in direct mode) */
 		showControls?: boolean;
 		/** UI mode - controls which UI elements are visible initially (e.g., "none", "none|title", "all") */
@@ -107,6 +110,7 @@
 		companionAssets,
 		title,
 		direct = false,
+		mode = DEFAULT_VIEWER_MODE,
 		showControls = false,
 		uiMode = 'none',
 		enableControls = true,
@@ -123,6 +127,17 @@
 		showEditorSwitch = false,
 		editorUrl
 	}: Props = $props();
+
+	// Derive control visibility from viewer mode
+	const effectiveShowControls = $derived(
+		mode === 'classic' ? false : showControls
+	);
+	const effectiveShowVoyagerMenu = $derived(
+		mode === 'standalone' ? true : mode === 'classic' ? false : showVoyagerMenu
+	);
+	const effectiveShowEditorSwitch = $derived(
+		mode === 'standalone' ? true : showEditorSwitch
+	);
 
 	// Compute the container style based on height prop
 	const containerStyle = $derived(
@@ -794,7 +809,7 @@
 	{:else if direct}
 		<!-- Direct Embedding Mode with Full API Control -->
 		<div class="voyager-container">
-		{#if showControls && isScriptLoaded}
+		{#if effectiveShowControls && isScriptLoaded}
 			<!-- Global UI Toggle -->
 			<div class="mb-4">
 				<button
@@ -1210,7 +1225,7 @@
 		</div>
 	{/if}
 
-	{#if showEditorSwitch}
+	{#if effectiveShowEditorSwitch}
 		<div class="flex flex-wrap items-center justify-between gap-3 bg-base-100/95 p-3">
 			<div class="join" role="group" aria-label="Voyager mode">
 				<button

--- a/src/lib/types/roles.ts
+++ b/src/lib/types/roles.ts
@@ -162,6 +162,23 @@ export const ROLE_LABELS: Record<string, string> = {
 	...GLOBAL_ROLE_LABELS
 };
 
+// Voyager viewer modes — control the UI complexity of the 3D viewer
+export type ViewerMode = 'classic' | 'expert' | 'standalone';
+
+export const VIEWER_MODE_LABELS: Record<ViewerMode, string> = {
+	classic: 'Classic',
+	expert: 'Expert',
+	standalone: 'Standalone'
+};
+
+export const VIEWER_MODE_DESCRIPTIONS: Record<ViewerMode, string> = {
+	classic: 'Minimal viewer — orbit and zoom only',
+	expert: 'Full controls — annotations, measurements, camera, background',
+	standalone: 'Expert controls + Voyager menu and story editor'
+};
+
+export const DEFAULT_VIEWER_MODE: ViewerMode = 'classic';
+
 // Edition status display labels
 export const STATUS_LABELS: Record<EditionStatus, string> = {
 	[EditionStatus.Draft]: 'Draft',

--- a/src/routes/editions/[slug]/+page.svelte
+++ b/src/routes/editions/[slug]/+page.svelte
@@ -23,6 +23,7 @@
 		type UserRoleContext
 	} from '$lib/types/roles';
 	import { hasPermission, canUserTransitionStatus } from '$lib/utils/permissions';
+	import { type ViewerMode, DEFAULT_VIEWER_MODE, VIEWER_MODE_LABELS } from '$lib/types/roles';
 	import { resolvePageContext } from '$lib/utils/page-permissions';
 	import { logAudit } from '$lib/utils/audit';
 	import toast from 'svelte-french-toast';
@@ -64,6 +65,11 @@
 
 	// Custom controls are the inverse of Voyager menu visibility
 	const showCustomControls = $derived(!showVoyagerMenu);
+
+	// Viewer mode — persisted per edition, defaults to classic
+	let viewerMode = $state<ViewerMode>(DEFAULT_VIEWER_MODE);
+	// Sync from edition data when it loads
+	$effect(() => { const m = (edition as any).viewerMode; if (m) viewerMode = m as ViewerMode; });
 
 	/**
 	 * Parse description text and extract view link markers
@@ -432,7 +438,28 @@
 						Compare editions
 					</button>
 				{/if}
-				<!-- Copy DOI -->
+				<!-- Viewer mode selector -->
+				<div class="dropdown dropdown-end">
+					<button class="btn btn-sm btn-ghost gap-1">
+						<span class="text-xs opacity-60">View:</span>
+						{VIEWER_MODE_LABELS[viewerMode]}
+						<svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+					</button>
+					<ul class="dropdown-content menu p-1 bg-base-100 rounded-box shadow w-52 z-10">
+						{#each (['classic','expert','standalone'] as ViewerMode[]) as m}
+							<li>
+								<button class:active={viewerMode === m} onclick={() => (viewerMode = m)}>
+									<div>
+										<div class="text-sm font-medium">{VIEWER_MODE_LABELS[m]}</div>
+										<div class="text-xs text-base-content/50">{m === 'classic' ? 'Orbit & zoom only' : m === 'expert' ? 'Full controls' : 'Expert + menu + editor'}</div>
+									</div>
+								</button>
+							</li>
+						{/each}
+					</ul>
+				</div>
+
+			<!-- Copy DOI -->
 				{#if primaryDoi}
 					<button class="btn btn-sm btn-ghost" onclick={copyDoi}>
 						{#if citationCopied}
@@ -572,6 +599,7 @@
 							onReady={handleViewerReady}
 							onFullWindowToggle={toggleFullWindow}
 							showEditorSwitch
+							mode={viewerMode}
 							{isFullWindow}
 							{showVoyagerMenu}
 						/>


### PR DESCRIPTION
## What

Adds three viewer complexity modes to the Voyager 3D viewer:

- **Classic** (default) — Minimal viewer with just orbit and zoom. Clean, no distractions.
- **Expert** — Full controls panel: annotations, measurements, tours, camera sliders, background styles, language selector.
- **Standalone** — Expert + Voyager's built-in menu + story editor switch.

### Changes

- `src/lib/types/roles.ts`: New `ViewerMode` type and constants
- `src/lib/components/voyager/VoyagerViewer.svelte`: Accepts `mode` prop, derives effective control/Menu/editor visibility
- `src/routes/editions/[slug]/+page.svelte`: Mode selector dropdown in the action bar

## Verification

- svelte-check: 0 errors, 0 warnings
- Build: passes